### PR TITLE
use comma-separated rightmost part as searchstr

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -368,6 +368,7 @@ fn build_cli<'a, 'b>() -> App<'a, 'b> {
             // We start by making 'fqn' the first positional arg, which will hold this dual value
             // of either an FQN as it says, or secretly a line-number
             .arg(Arg::with_name("fqn")
+                .use_delimiter(false)
                 .help("complete with a fully-qualified-name (e.g. std::io::)"))
             .arg(Arg::with_name("charnum")
                 .help("The char number to search for matches")

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1049,7 +1049,13 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
     debug!("do_external_search path {:?} {:?}", path, filepath.to_str());
     let mut out = Vec::new();
     if path.len() == 1 {
-        let searchstr = path[0];
+        let mut searchstr = path[0];
+        if let Some(i) = searchstr.rfind(',') {
+            searchstr = &searchstr[i+1..].trim();
+        }
+        if searchstr.chars().next() == Some('{') {
+            searchstr = &searchstr[1..];
+        }
         // hack for now
         let pathseg = core::PathSegment{name: searchstr.to_owned(),
                                          types: Vec::new()};
@@ -1075,16 +1081,22 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
         let parent_path = &path[..(path.len()-1)];
         let context = do_external_search(parent_path, filepath, pos, ExactMatch, TypeNamespace, session).nth(0);
         context.map(|m| {
+            // process searchstr:
+            // In case there is comma inside, we use rightmost part as searchstr
+            // In case there is leading bracket, we ignore it
+            // so "foo::{bar" will be same as "foo::bar"
+            let mut searchstr = path[path.len()-1];
+            if let Some(i) = searchstr.rfind(',') {
+                searchstr = &searchstr[i+1..].trim();
+            }
+            if searchstr.chars().next() == Some('{') {
+                searchstr = &searchstr[1..];
+            }
+            let pathseg = core::PathSegment{name: searchstr.to_owned(),
+                                 types: Vec::new()};
             match m.mtype {
                 Module => {
                     debug!("found an external module {}", m.matchstr);
-                    // deal with started with "{", so that "foo::{bar" will be same as "foo::bar"
-                    let searchstr = match path[path.len()-1].chars().next() {
-                        Some('{') => &path[path.len()-1][1..],
-                        _ => path[path.len()-1]
-                    };
-                    let pathseg = core::PathSegment{name: searchstr.to_owned(),
-                                         types: Vec::new()};
                     for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, false, namespace, session) {
                         out.push(m);
                     }
@@ -1094,13 +1106,6 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
                     debug!("found a pub struct. Now need to look for impl");
                     for m in search_for_impls(m.point, &m.matchstr, &m.filepath, m.local, false, session) {
                         debug!("found  impl2!! {}", m.matchstr);
-                        // deal with started with "{", so that "foo::{bar" will be same as "foo::bar"
-                        let searchstr = match path[path.len()-1].chars().next() {
-                            Some('{') => &path[path.len()-1][1..],
-                            _ => path[path.len()-1]
-                        };
-                        let pathseg = core::PathSegment{name: searchstr.to_owned(),
-                                         types: Vec::new()};
                         debug!("about to search impl scope...");
                         for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, m.local, namespace, session) {
                             out.push(m);


### PR DESCRIPTION
In previous version, multiple use is not handle correctly
The comma separated use cannot get right completion.
First the clap prevent comma being parsed into fqn,
we need to enable it by setting `use_delimiter` false.

The searchstr is now being processed as below:
1. If there is comma, take the rightmost part as search string.
2. If there is leading bracket, ignore it.

This will close issue 96 except that multiple use ignore those module already being use.
For example, complete `std::io::{BufReader, B` will still have `BufReader` in output.
Issue #96 suggests that in above case BufReader should not appear. I think this is only tiny `bug` and not very inconvenient to our daily use.
