### PR TITLE
Add tests for #628.

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1977,6 +1977,48 @@ fn finds_self_param_when_fn_has_generic_closure_arg() {
 }
 
 #[test]
+fn works_with_character_literals_containing_one_character() {
+    // issue #628
+    let src = "
+    struct Foo {
+        bar: char,
+    }
+
+    impl Foo {
+        pub fn baz(&self) {
+        }
+    }
+
+    let foo = Foo { bar: 'a', };
+    foo.~baz
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("baz", got.matchstr);
+}
+
+#[test]
+fn works_with_character_literals_containing_more_than_one_character() {
+    // issue #628
+    let src = "
+    struct Foo {
+        bar: char,
+    }
+
+    impl Foo {
+        pub fn baz(&self) {
+        }
+    }
+
+    let foo = Foo { bar: '\\n', };
+    foo.~baz
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("baz", got.matchstr);
+}
+
+#[test]
 fn completes_methods_on_deref_generic_type() {
     let modsrc = "
     pub trait Deref {


### PR DESCRIPTION
First test passes, second test fails in the same way as #628

```
error: character literal may only contain one codepoint: '
 --> bogofile:1:22
  |
1 | let foo = Foo { bar: '  ', }
  |                      ^^

test works_with_character_literals_containing_more_than_one_character ... FAILED

failures:

---- works_with_character_literals_containing_more_than_one_character stdout ----
        thread 'works_with_character_literals_containing_more_than_one_character' panicked at 'Box<Any>', C:\Users\Arnavion\.cargo\registry\src\github.com-1ecc6299db9ec823\syntex_syntax-0.43.0\src\parse\lexer/mod.rs:1279
```
