### PR TITLE
Fix #683: do not ignore empty module doc lines

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -723,7 +723,7 @@ fn find_mod_doc(msrc: &str, blobstart: usize) -> String {
         // Skip over the copyright notice and empty lines until you find
         // the module's documentation (it will go until the end of the
         // file if the module doesn't have any docs).
-        .filter(|line| line.starts_with("//! "))
+        .filter(|line| line.starts_with("//!"))
         .peekable();
 
     // Use a loop to avoid unnecessary collect and String allocation

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1062,6 +1062,33 @@ fn finds_external_fn_docs() {
 }
 
 #[test]
+fn keeps_newlines_in_external_mod_doc() {
+    let _lock = sync!();
+
+    // issue 683: do not remove newlines inside of mod-doc
+    let src1 = "// Copyright notice
+
+//! The mods multiline documentation
+//!
+//! with an empty line
+    ";
+    let src = "
+    mod external_mod;
+    use external_mod;
+
+    fn main() {
+        external_mod~
+    }
+    ";
+
+    let dir = TmpDir::new();
+    dir.write_file("external_mod.rs", src1);
+    let got = get_one_completion(src, Some(dir));
+    assert_eq!("external_mod", got.matchstr);
+    assert_eq!("The mods multiline documentation\n\nwith an empty line", got.docs);
+}
+
+#[test]
 fn issue_618() {
     let _lock = sync!();
 


### PR DESCRIPTION
## Problem
Racer expected an empty module documentation line to start with <code>//! </code>, including a space. The Rust documentation does not include this space (at least not in `std::path`) , thus racer ignores all empty lines of the documentation, resulting in markdown being rendered differently in some cases (see #683).

## Solution
This PR modifies the pattern to `//!`, excluding the space, to fix this.

## Possible Issues
None that I am aware of.