### PR TITLE
Add method autocompletions on common string literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/scopes
 *.racertmp
 target/
 *.py[cod]
+.vscode/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache: cargo
 before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH
+  - rustup component add rust-src
+  - export RUST_SRC_PATH=`rustc --print sysroot`/lib/rustlib/src/rust/src
 
 script:
   - travis-cargo --skip nightly-2016-11-25 test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - Find static methods on enums #737
+- Find methods on cooked string literals #728
 
 ## 2.0.8
 

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use syntex_errors::Handler;
 use syntex_errors::emitter::ColorConfig;
-use syntex_syntax::ast::{self, ExprKind, FunctionRetTy, ItemKind, PatKind, TyKind, TyParamBound};
+use syntex_syntax::ast::{self, ExprKind, FunctionRetTy, ItemKind, LitKind, PatKind, TyKind, TyParamBound};
 use syntex_syntax::codemap;
 use syntex_syntax::parse::parser::Parser;
 use syntex_syntax::parse::{lexer, ParseSess};

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -587,8 +587,23 @@ impl<'c, 's> visit::Visitor for ExprTypeVisitor<'c, 's> {
                 self.result = Some(Ty::Tuple(v));
             }
 
-            ExprKind::Lit(_) => {
-                self.result = Some(Ty::Unsupported);
+            ExprKind::Lit(ref lit) => {
+                let ty_path = match lit.node {
+                    LitKind::Str(_, _) => {
+                        Some(core::Path::from_vec(false, vec!["str"]))
+                    },
+                    // See https://github.com/phildawes/racer/issues/727 for 
+                    // information on why other literals aren't supported.
+                    _ => None,
+                };
+
+                self.result = if let Some(lit_path) = ty_path {
+                    find_type_match(&lit_path, &self.scope.filepath,
+                                              self.scope.point,
+                                              self.session)
+                } else {
+                    Some(Ty::Unsupported)
+                };
             }
 
             ExprKind::TupField(ref subexpression, ref spanned_index) => {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -317,7 +317,7 @@ pub struct PathSegment {
 impl From<String> for PathSegment {
     fn from(name: String) -> Self {
         PathSegment {
-            name,
+            name: name,
             types: Vec::new(),
         }
     }

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -243,7 +243,7 @@ impl Path {
     pub fn from_svec(global: bool, v: Vec<String>) -> Path {
         let segs = v
             .into_iter()
-            .map(|x| PathSegment{ name: x, types: Vec::new() })
+            .map(PathSegment::from)
             .collect::<Vec<_>>();
         Path{ global: global, segments: segs }
     }
@@ -312,6 +312,15 @@ impl fmt::Display for Path {
 pub struct PathSegment {
     pub name: String,
     pub types: Vec<Path>
+}
+
+impl From<String> for PathSegment {
+    fn from(name: String) -> Self {
+        PathSegment {
+            name,
+            types: Vec::new(),
+        }
+    }
 }
 
 /// Information about generic types in a match

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -208,6 +208,7 @@ pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {
 
     enum State {
         Levels(usize),
+        StringLiteral,
         StartsWithDot,
         MustEndsWithDot(usize),
         StartsWithCol(usize),
@@ -228,6 +229,10 @@ pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {
             (b'.', State::MustEndsWithDot(_)) =>  State::None,
             (b':', State::MustEndsWithDot(index)) =>  State::StartsWithCol(index),
             (b':', State::StartsWithCol(_)) =>  State::None,
+            (b'"', State::None) |
+            (b'"', State::StartsWithDot) => State::StringLiteral,
+            (b'"', State::StringLiteral) => State::None,
+            (_ , State::StringLiteral) => State::StringLiteral,
             ( _ , State::StartsWithCol(index)) => State::Result(index) ,
             ( _ , State::None) if char_at(src, i).is_whitespace() =>  State::MustEndsWithDot(i+1),
             ( _ , State::MustEndsWithDot(index)) if char_at(src, i).is_whitespace() => State::MustEndsWithDot(index),

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -207,7 +207,9 @@ pub fn get_line(src: &str, point: usize) -> usize {
 pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {
 
     enum State {
+        /// In parentheses; the value inside identifies depth.
         Levels(usize),
+        /// In a string
         StringLiteral,
         StartsWithDot,
         MustEndsWithDot(usize),

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3046,3 +3046,16 @@ fn closure_bracket_scope_nested_match_outside() {
     assert_eq!("x", got.matchstr);
     assert_eq!("| x: i32 |", got.contextstr);
 }
+
+#[test]
+fn literal_string_method() {
+    let _lock = sync!();
+    let src = r#"
+        fn check() {
+            "hello".st~arts_with("he");
+        }
+    "#;
+
+    let got = get_definition(src, None);
+    assert_eq!("starts_with", got.matchstr);
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3227,3 +3227,18 @@ fn literal_string_method() {
     let got = get_definition(src, None);
     assert_eq!("starts_with", got.matchstr);
 }
+
+#[test]
+fn literal_string_completes() {
+    let _lock = sync!();
+    let src = r#"
+    fn in_let() {
+        let foo = "hello";
+        foo.end~s_with("lo");
+    }
+    "#;
+
+    let got = get_all_completions(src, None);
+    assert_eq!(1, got.len());
+    assert_eq!("ends_with", got[0].matchstr);
+}


### PR DESCRIPTION
This adds partial support for method completions on string literals (requested in #443), with some caveats:

1. Raw strings aren't supported
2. Escaped quotation marks in cooked strings could cause problems

Both of these are omitted because they would require looking ahead one or more characters, which the loop in `scopes:: get_start_of_search_expr` isn't set up for right now.