### PR TITLE
Use meaningful type aliases for points and ranges

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,7 +6,7 @@ extern crate env_logger;
 
 extern crate racer;
 
-use racer::{Match, MatchType, FileCache, Session, Coordinate};
+use racer::{Match, MatchType, FileCache, Session, Coordinate, Point};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::io::{self, BufRead, Read};
@@ -196,9 +196,9 @@ fn daemon(cfg: Config) {
 
 enum Message<'a> {
     End,
-    Prefix(usize, usize, &'a str),
-    Match(String, usize, usize, &'a Path, MatchType, String),
-    MatchWithSnippet(String, String, usize, usize, &'a Path, MatchType, String, String),
+    Prefix(Point, Point, &'a str),
+    Match(String, Point, Point, &'a Path, MatchType, String),
+    MatchWithSnippet(String, String, Point, Point, &'a Path, MatchType, String, String),
 }
 
 #[derive(Copy, Clone)]

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1,4 +1,4 @@
-use core::{self, Match, MatchType, Scope, Ty, Session, SessionExt, Point, SourceRange};
+use core::{self, Match, MatchType, Scope, Ty, Session, SessionExt, Point, SourceByteRange};
 use typeinf;
 use nameres::{self, resolve_path_with_str};
 use scopes;
@@ -100,7 +100,7 @@ impl visit::Visitor for UseVisitor {
 }
 
 pub struct PatBindVisitor {
-    ident_points: Vec<SourceRange>
+    ident_points: Vec<SourceByteRange>
 }
 
 impl visit::Visitor for PatBindVisitor {
@@ -137,7 +137,7 @@ impl visit::Visitor for PatBindVisitor {
 }
 
 pub struct PatVisitor {
-    ident_points: Vec<SourceRange>
+    ident_points: Vec<SourceByteRange>
 }
 
 impl visit::Visitor for PatVisitor {
@@ -951,7 +951,7 @@ pub fn parse_use(s: String) -> UseVisitor {
     v
 }
 
-pub fn parse_pat_bind_stmt(s: String) -> Vec<SourceRange> {
+pub fn parse_pat_bind_stmt(s: String) -> Vec<SourceByteRange> {
     let mut v = PatBindVisitor{ ident_points: Vec::new() };
     if let Some(stmt) = string_to_stmt(s) {
         visit::walk_stmt(&mut v, &stmt);
@@ -999,11 +999,11 @@ pub fn parse_type(s: String) -> TypeVisitor {
     v
 }
 
-pub fn parse_fn_args(s: String) -> Vec<SourceRange> {
+pub fn parse_fn_args(s: String) -> Vec<SourceByteRange> {
     parse_pat_idents(s)
 }
 
-pub fn parse_pat_idents(s: String) -> Vec<SourceRange> {
+pub fn parse_pat_idents(s: String) -> Vec<SourceByteRange> {
     let mut v = PatVisitor{ ident_points: Vec::new() };
     if let Some(stmt) = string_to_stmt(s) {
         debug!("parse_pat_idents stmt is {:?}", stmt);
@@ -1157,7 +1157,7 @@ fn ast_sandbox() {
 
     // let src = "(myvar, foo) = (3,4);";
 
-    // let src = "fn myfn((a,b) : SourceRange) {}";
+    // let src = "fn myfn((a,b) : SourceByteRange) {}";
     // //let src = "impl blah {pub fn another_method() {}}";
 
     // let stmt = string_to_stmt(String::from_str(src));

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1,4 +1,4 @@
-use core::{self, Match, MatchType, Scope, Ty, Session, SessionExt};
+use core::{self, Match, MatchType, Scope, Ty, Session, SessionExt, Point, SourceRange};
 use typeinf;
 use nameres::{self, resolve_path_with_str};
 use scopes;
@@ -100,7 +100,7 @@ impl visit::Visitor for UseVisitor {
 }
 
 pub struct PatBindVisitor {
-    ident_points: Vec<(usize, usize)>
+    ident_points: Vec<SourceRange>
 }
 
 impl visit::Visitor for PatBindVisitor {
@@ -137,7 +137,7 @@ impl visit::Visitor for PatBindVisitor {
 }
 
 pub struct PatVisitor {
-    ident_points: Vec<(usize, usize)>
+    ident_points: Vec<SourceRange>
 }
 
 impl visit::Visitor for PatVisitor {
@@ -197,7 +197,7 @@ fn point_is_in_span(point: u32, span: &codemap::Span) -> bool {
 
 // The point must point to an ident within the pattern.
 fn destructure_pattern_to_ty(pat: &ast::Pat,
-                             point: usize,
+                             point: Point,
                              ty: &Ty,
                              scope: &Scope,
                              session: &Session) -> Option<Ty> {
@@ -292,7 +292,7 @@ struct LetTypeVisitor<'c: 's, 's> {
     scope: Scope,
     session: &'s Session<'c>,
     srctxt: String,
-    pos: usize,        // pos is relative to the srctxt, scope is global
+    pos: Point,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
@@ -341,7 +341,7 @@ impl<'c, 's> visit::Visitor for LetTypeVisitor<'c, 's> {
 struct MatchTypeVisitor<'c: 's, 's> {
     scope: Scope,
     session: &'s Session<'c>,
-    pos: usize,        // pos is relative to the srctxt, scope is global
+    pos: Point,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
@@ -370,7 +370,7 @@ impl<'c, 's> visit::Visitor for MatchTypeVisitor<'c, 's> {
     }
 }
 
-fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: usize, session: &Session) -> Option<Match> {
+fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: Point, session: &Session) -> Option<Match> {
     debug!("resolve_ast_path {:?}", to_racer_path(path));
     nameres::resolve_path_with_str(&to_racer_path(path), filepath, pos, core::SearchType::ExactMatch,
                                    core::Namespace::Both, session).nth(0)
@@ -402,7 +402,7 @@ fn path_to_match(ty: Ty, session: &Session) -> Option<Ty> {
     }
 }
 
-fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &Session) -> Option<Ty> {
+fn find_type_match(path: &core::Path, fpath: &Path, pos: Point, session: &Session) -> Option<Ty> {
     debug!("find_type_match {:?}, {:?}", path, fpath);
     let res = resolve_path_with_str(path, fpath, pos, core::SearchType::ExactMatch,
                core::Namespace::Type, session).nth(0).and_then(|m| {
@@ -674,7 +674,7 @@ fn path_to_match_including_generics(ty: Ty, contextm: &Match, session: &Session)
 
 fn find_type_match_including_generics(fieldtype: &core::Ty,
                                       filepath: &Path,
-                                      pos: usize,
+                                      pos: Point,
                                       structm: &Match,
                                       session: &Session) -> Option<Ty>{
     assert_eq!(&structm.filepath, filepath);
@@ -715,7 +715,7 @@ fn find_type_match_including_generics(fieldtype: &core::Ty,
 
 struct StructVisitor {
     pub scope: Scope,
-    pub fields: Vec<(String, usize, Option<core::Ty>)>
+    pub fields: Vec<(String, Point, Option<core::Ty>)>
 }
 
 impl visit::Visitor for StructVisitor {
@@ -878,7 +878,7 @@ impl visit::Visitor for GenericsVisitor {
 
 pub struct EnumVisitor {
     pub name: String,
-    pub values: Vec<(String, usize)>
+    pub values: Vec<(String, Point)>
 }
 
 impl visit::Visitor for EnumVisitor {
@@ -908,7 +908,7 @@ pub fn parse_use(s: String) -> UseVisitor {
     v
 }
 
-pub fn parse_pat_bind_stmt(s: String) -> Vec<(usize, usize)> {
+pub fn parse_pat_bind_stmt(s: String) -> Vec<SourceRange> {
     let mut v = PatBindVisitor{ ident_points: Vec::new() };
     if let Some(stmt) = string_to_stmt(s) {
         visit::walk_stmt(&mut v, &stmt);
@@ -916,7 +916,7 @@ pub fn parse_pat_bind_stmt(s: String) -> Vec<(usize, usize)> {
     v.ident_points
 }
 
-pub fn parse_struct_fields(s: String, scope: Scope) -> Vec<(String, usize, Option<core::Ty>)> {
+pub fn parse_struct_fields(s: String, scope: Scope) -> Vec<(String, Point, Option<core::Ty>)> {
     let mut v = StructVisitor{ scope: scope, fields: Vec::new() };
     if let Some(stmt) = string_to_stmt(s) {
         visit::walk_stmt(&mut v, &stmt);
@@ -956,11 +956,11 @@ pub fn parse_type(s: String) -> TypeVisitor {
     v
 }
 
-pub fn parse_fn_args(s: String) -> Vec<(usize, usize)> {
+pub fn parse_fn_args(s: String) -> Vec<SourceRange> {
     parse_pat_idents(s)
 }
 
-pub fn parse_pat_idents(s: String) -> Vec<(usize, usize)> {
+pub fn parse_pat_idents(s: String) -> Vec<SourceRange> {
     let mut v = PatVisitor{ ident_points: Vec::new() };
     if let Some(stmt) = string_to_stmt(s) {
         debug!("parse_pat_idents stmt is {:?}", stmt);
@@ -979,7 +979,7 @@ pub fn parse_fn_output(s: String, scope: Scope) -> Option<core::Ty> {
     v.result
 }
 
-pub fn parse_fn_arg_type(s: String, argpos: usize, scope: Scope, session: &Session) -> Option<core::Ty> {
+pub fn parse_fn_arg_type(s: String, argpos: Point, scope: Scope, session: &Session) -> Option<core::Ty> {
     debug!("parse_fn_arg {} |{}|", argpos, s);
     let mut v = FnArgTypeVisitor { argpos: argpos, scope: scope, result: None,
                                    session: session };
@@ -1013,7 +1013,7 @@ pub fn parse_enum(s: String) -> EnumVisitor {
     v
 }
 
-pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: &Session) -> Option<Ty> {
+pub fn get_type_of(exprstr: String, fpath: &Path, pos: Point, session: &Session) -> Option<Ty> {
     let startscope = Scope {
         filepath: fpath.to_path_buf(),
         point: pos
@@ -1028,7 +1028,7 @@ pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: &Session)
 }
 
 // pos points to an ident in the lhs of the stmtstr
-pub fn get_let_type(stmtstr: String, pos: usize, scope: Scope, session: &Session) -> Option<Ty> {
+pub fn get_let_type(stmtstr: String, pos: Point, scope: Scope, session: &Session) -> Option<Ty> {
     let mut v = LetTypeVisitor {
         scope: scope,
         session: session,
@@ -1041,7 +1041,7 @@ pub fn get_let_type(stmtstr: String, pos: usize, scope: Scope, session: &Session
     v.result
 }
 
-pub fn get_match_arm_type(stmtstr: String, pos: usize, scope: Scope, session: &Session) -> Option<Ty> {
+pub fn get_match_arm_type(stmtstr: String, pos: Point, scope: Scope, session: &Session) -> Option<Ty> {
     let mut v = MatchTypeVisitor {
         scope: scope,
         session: session,
@@ -1069,7 +1069,7 @@ impl visit::Visitor for FnOutputVisitor {
 }
 
 pub struct FnArgTypeVisitor<'c: 's, 's> {
-    argpos: usize,
+    argpos: Point,
     scope: Scope,
     session: &'s Session<'c>,
     pub result: Option<Ty>
@@ -1114,7 +1114,7 @@ fn ast_sandbox() {
 
     // let src = "(myvar, foo) = (3,4);";
 
-    // let src = "fn myfn((a,b) : (usize, usize)) {}";
+    // let src = "fn myfn((a,b) : SourceRange) {}";
     // //let src = "impl blah {pub fn another_method() {}}";
 
     // let stmt = string_to_stmt(String::from_str(src));

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -1,4 +1,4 @@
-use core::{Point, SourceRange};
+use core::{Point, SourceByteRange};
 
 #[derive(Clone,Copy)]
 enum State {
@@ -18,10 +18,10 @@ pub struct CodeIndicesIter<'a> {
 }
 
 impl<'a> Iterator for CodeIndicesIter<'a> {
-    type Item = SourceRange;
+    type Item = SourceByteRange;
 
     #[inline]
-    fn next(&mut self) -> Option<SourceRange> {
+    fn next(&mut self) -> Option<SourceByteRange> {
         match self.state {
             State::Code => Some(self.code()),
             State::Comment => Some(self.comment()),
@@ -34,7 +34,7 @@ impl<'a> Iterator for CodeIndicesIter<'a> {
 }
 
 impl<'a> CodeIndicesIter<'a> {
-    fn code(&mut self) -> SourceRange {
+    fn code(&mut self) -> SourceByteRange {
         let mut pos = self.pos;
         let start = match self.state {
             State::String |
@@ -83,7 +83,7 @@ impl<'a> CodeIndicesIter<'a> {
         (start, self.src.len())
     }
 
-    fn comment(&mut self) -> SourceRange {
+    fn comment(&mut self) -> SourceByteRange {
         let mut pos = self.pos;
         let src_bytes = self.src.as_bytes();
         for &b in &src_bytes[pos..] {
@@ -99,7 +99,7 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn comment_block(&mut self) -> SourceRange {
+    fn comment_block(&mut self) -> SourceByteRange {
         let mut nesting_level = 0usize;
         let mut prev = b' ';
         let mut pos = self.pos;
@@ -123,7 +123,7 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn string(&mut self) -> SourceRange {
+    fn string(&mut self) -> SourceByteRange {
         let src_bytes = self.src.as_bytes();
         let mut pos = self.pos;
         if pos > 1 && src_bytes[pos-2] == b'r' {
@@ -147,7 +147,7 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn char(&mut self) -> SourceRange {
+    fn char(&mut self) -> SourceByteRange {
         let mut is_not_escaped = true;
         let mut pos = self.pos;
         for &b in &self.src.as_bytes()[pos..] {

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -1,3 +1,5 @@
+use core::{Point, SourceRange};
+
 #[derive(Clone,Copy)]
 enum State {
     Code,
@@ -11,15 +13,15 @@ enum State {
 #[derive(Clone,Copy)]
 pub struct CodeIndicesIter<'a> {
     src: &'a str,
-    pos: usize,
+    pos: Point,
     state: State
 }
 
 impl<'a> Iterator for CodeIndicesIter<'a> {
-    type Item = (usize, usize);
+    type Item = SourceRange;
 
     #[inline]
-    fn next(&mut self) -> Option<(usize, usize)> {
+    fn next(&mut self) -> Option<SourceRange> {
         match self.state {
             State::Code => Some(self.code()),
             State::Comment => Some(self.comment()),
@@ -32,7 +34,7 @@ impl<'a> Iterator for CodeIndicesIter<'a> {
 }
 
 impl<'a> CodeIndicesIter<'a> {
-    fn code(&mut self) -> (usize, usize) {
+    fn code(&mut self) -> SourceRange {
         let mut pos = self.pos;
         let start = match self.state {
             State::String |
@@ -81,7 +83,7 @@ impl<'a> CodeIndicesIter<'a> {
         (start, self.src.len())
     }
 
-    fn comment(&mut self) -> (usize, usize) {
+    fn comment(&mut self) -> SourceRange {
         let mut pos = self.pos;
         let src_bytes = self.src.as_bytes();
         for &b in &src_bytes[pos..] {
@@ -97,7 +99,7 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn comment_block(&mut self) -> (usize, usize) {
+    fn comment_block(&mut self) -> SourceRange {
         let mut nesting_level = 0usize;
         let mut prev = b' ';
         let mut pos = self.pos;
@@ -121,7 +123,7 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn string(&mut self) -> (usize, usize) {
+    fn string(&mut self) -> SourceRange {
         let src_bytes = self.src.as_bytes();
         let mut pos = self.pos;
         if pos > 1 && src_bytes[pos-2] == b'r' {
@@ -145,7 +147,7 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn char(&mut self) -> (usize, usize) {
+    fn char(&mut self) -> SourceRange {
         let mut is_not_escaped = true;
         let mut pos = self.pos;
         for &b in &self.src.as_bytes()[pos..] {

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -1,21 +1,23 @@
 use std::iter::{Fuse, Iterator};
 
+use core::{Point, SourceRange};
+
 pub struct StmtIndicesIter<'a,I>
-    where I: Iterator<Item=(usize,usize)>
+    where I: Iterator<Item=SourceRange>
 {
     src: &'a str,
     it: I,
-    pos: usize,
-    end: usize
+    pos: Point,
+    end: Point
 }
 
 impl<'a,I> Iterator for StmtIndicesIter<'a,I>
-    where I: Iterator<Item=(usize,usize)>
+    where I: Iterator<Item=SourceRange>
 {
-    type Item = (usize, usize);
+    type Item = SourceRange;
 
     #[inline]
-    fn next(&mut self) -> Option<(usize, usize)> {
+    fn next(&mut self) -> Option<SourceRange> {
         let src_bytes = self.src.as_bytes();
         let mut enddelim = b';';
         let mut bracelevel = 0isize;
@@ -108,7 +110,7 @@ impl<'a,I> Iterator for StmtIndicesIter<'a,I>
     }
 }
 
-fn is_a_use_stmt(src_bytes: &[u8], start: usize, pos: usize) -> bool {
+fn is_a_use_stmt(src_bytes: &[u8], start: Point, pos: Point) -> bool {
     let whitespace = b" {\t\r\n";
     (pos > 3 && &src_bytes[start..start+3] == b"use" &&
      whitespace.contains(&src_bytes[start+3])) ||
@@ -116,13 +118,13 @@ fn is_a_use_stmt(src_bytes: &[u8], start: usize, pos: usize) -> bool {
      whitespace.contains(&src_bytes[start+7]))
 }
 
-fn is_a_let_stmt(src_bytes: &[u8], start: usize, pos: usize) -> bool {
+fn is_a_let_stmt(src_bytes: &[u8], start: Point, pos: Point) -> bool {
     let whitespace = b" {\t\r\n";
     pos > 3 && &src_bytes[start..start+3] == b"let" && whitespace.contains(&src_bytes[start+3])
 }
 
 impl<'a, I> StmtIndicesIter<'a,I>
-    where I: Iterator<Item=(usize,usize)>
+    where I: Iterator<Item=SourceRange>
 {
     pub fn from_parts(src: &str, it: I) -> Fuse<StmtIndicesIter<I>> {
         StmtIndicesIter{ src: src, it: it, pos: 0, end: 0 }.fuse()

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -1,9 +1,9 @@
 use std::iter::{Fuse, Iterator};
 
-use core::{Point, SourceRange};
+use core::{Point, SourceByteRange};
 
 pub struct StmtIndicesIter<'a,I>
-    where I: Iterator<Item=SourceRange>
+    where I: Iterator<Item=SourceByteRange>
 {
     src: &'a str,
     it: I,
@@ -12,12 +12,12 @@ pub struct StmtIndicesIter<'a,I>
 }
 
 impl<'a,I> Iterator for StmtIndicesIter<'a,I>
-    where I: Iterator<Item=SourceRange>
+    where I: Iterator<Item=SourceByteRange>
 {
-    type Item = SourceRange;
+    type Item = SourceByteRange;
 
     #[inline]
-    fn next(&mut self) -> Option<SourceRange> {
+    fn next(&mut self) -> Option<SourceByteRange> {
         let src_bytes = self.src.as_bytes();
         let mut enddelim = b';';
         let mut bracelevel = 0isize;
@@ -124,7 +124,7 @@ fn is_a_let_stmt(src_bytes: &[u8], start: Point, pos: Point) -> bool {
 }
 
 impl<'a, I> StmtIndicesIter<'a,I>
-    where I: Iterator<Item=SourceRange>
+    where I: Iterator<Item=SourceByteRange>
 {
     pub fn from_parts(src: &str, it: I) -> Fuse<StmtIndicesIter<I>> {
         StmtIndicesIter{ src: src, it: it, pos: 0, end: 0 }.fuse()

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -70,7 +70,7 @@ pub enum CompletionType {
 pub type Point = usize;
 
 /// A range of text between two positions.
-pub type SourceRange = (Point, Point);
+pub type SourceByteRange = (Point, Point);
 
 /// Line and Column position in a file
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
@@ -348,8 +348,8 @@ impl fmt::Debug for PathSearch {
 
 pub struct IndexedSource {
     pub code: String,
-    pub idx: Vec<SourceRange>,
-    pub lines: RefCell<Vec<SourceRange>>
+    pub idx: Vec<SourceByteRange>,
+    pub lines: RefCell<Vec<SourceByteRange>>
 }
 
 #[derive(Clone,Copy)]
@@ -524,13 +524,13 @@ impl<'c> Src<'c> {
 // N.b. src can be a substr, so iteration skips chunks that aren't part of the substr
 pub struct CodeChunkIter<'c> {
     src: Src<'c>,
-    iter: slice::Iter<'c, SourceRange>
+    iter: slice::Iter<'c, SourceByteRange>
 }
 
 impl<'c> Iterator for CodeChunkIter<'c> {
-    type Item = SourceRange;
+    type Item = SourceByteRange;
 
-    fn next(&mut self) -> Option<SourceRange> {
+    fn next(&mut self) -> Option<SourceByteRange> {
         loop {
             match self.iter.next() {
                 None => return None,

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -31,7 +31,7 @@ mod cargo;
 pub use core::{find_definition, complete_from_file, complete_fully_qualified_name};
 pub use snippets::snippet_for_match;
 pub use core::{Match, MatchType, PathSearch};
-pub use core::{FileCache, Session, Coordinate, Location, FileLoader, Point, SourceRange};
+pub use core::{FileCache, Session, Coordinate, Location, FileLoader, Point, SourceByteRange};
 pub use util::expand_ident;
 
 pub use util::{RustSrcPathError, check_rust_src_env_var};

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -31,7 +31,7 @@ mod cargo;
 pub use core::{find_definition, complete_from_file, complete_fully_qualified_name};
 pub use snippets::snippet_for_match;
 pub use core::{Match, MatchType, PathSearch};
-pub use core::{FileCache, Session, Coordinate, Location, FileLoader};
+pub use core::{FileCache, Session, Coordinate, Location, FileLoader, Point, SourceRange};
 pub use util::expand_ident;
 
 pub use util::{RustSrcPathError, check_rust_src_env_var};

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -1,5 +1,5 @@
 use {scopes, typeinf, ast};
-use core::{Match, PathSegment, Src, Session, Coordinate, SessionExt};
+use core::{Match, PathSegment, Src, Session, Coordinate, SessionExt, Point};
 use util::{StackLinkedListNode, symbol_matches, txt_matches, find_ident_end, is_ident_char, char_at};
 use nameres::{get_module_file, get_crate_file, resolve_path};
 use core::SearchType::{self, StartsWith, ExactMatch};
@@ -13,8 +13,8 @@ use std::{iter, option, str, vec};
 #[derive(PartialEq, Eq)]
 pub struct PendingImport<'fp> {
     filepath: &'fp Path,
-    blobstart: usize,
-    blobend: usize,
+    blobstart: Point,
+    blobend: Point,
 }
 
 /// A stack of imports (`use` items) currently being resolved.
@@ -24,7 +24,7 @@ pub type MIter = option::IntoIter<Match>;
 pub type MChain<T> = iter::Chain<T, MIter>;
 
 // Should I return a boxed trait object to make this signature nicer?
-pub fn match_types(src: Src, blobstart: usize, blobend: usize,
+pub fn match_types(src: Src, blobstart: Point, blobend: Point,
                    searchstr: &str, filepath: &Path,
                    search_type: SearchType,
                    local: bool, session: &Session,
@@ -38,7 +38,7 @@ pub fn match_types(src: Src, blobstart: usize, blobend: usize,
     it.chain(match_use(&src, blobstart, blobend, searchstr, filepath, search_type, local, session, pending_imports).into_iter())
 }
 
-pub fn match_values(src: Src, blobstart: usize, blobend: usize,
+pub fn match_values(src: Src, blobstart: Point, blobend: Point,
                     searchstr: &str, filepath: &Path, search_type: SearchType,
                     local: bool) -> MChain<MChain<MChain<MIter>>> {
     let it = match_const(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter();
@@ -48,7 +48,7 @@ pub fn match_values(src: Src, blobstart: usize, blobend: usize,
 }
 
 fn find_keyword(src: &str, pattern: &str, search: &str, search_type: SearchType, local: bool)
--> Option<usize> {
+-> Option<Point> {
     // search for "^(pub\s+)?(unsafe\s+)?pattern\s+search"
 
     // if not local must start with pub
@@ -105,11 +105,11 @@ fn find_keyword(src: &str, pattern: &str, search: &str, search_type: SearchType,
     }
 }
 
-fn is_const_fn(src: &str, blobstart: usize, blobend: usize) -> bool {
+fn is_const_fn(src: &str, blobstart: Point, blobend: Point) -> bool {
     src[blobstart..blobend].contains("const fn")
 }
 
-fn match_pattern_start(src: &str, blobstart: usize, blobend: usize,
+fn match_pattern_start(src: &str, blobstart: Point, blobend: Point,
                        searchstr: &str, filepath: &Path, search_type: SearchType,
                        local: bool, pattern: &str, mtype: MatchType) -> Option<Match> {
     // ast currently doesn't contain the ident coords, so match them with a hacky
@@ -136,7 +136,7 @@ fn match_pattern_start(src: &str, blobstart: usize, blobend: usize,
     None
 }
 
-pub fn match_const(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_const(msrc: &str, blobstart: Point, blobend: Point,
                    searchstr: &str, filepath: &Path, search_type: SearchType,
                    local: bool) -> Option<Match> {
     if is_const_fn(msrc, blobstart, blobend) {
@@ -146,14 +146,14 @@ pub fn match_const(msrc: &str, blobstart: usize, blobend: usize,
                         search_type, local, "const", Const)
 }
 
-pub fn match_static(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_static(msrc: &str, blobstart: Point, blobend: Point,
                     searchstr: &str, filepath: &Path, search_type: SearchType,
                     local: bool) -> Option<Match> {
     match_pattern_start(msrc, blobstart, blobend, searchstr, filepath,
                         search_type, local, "static", Static)
 }
 
-fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
+fn match_pattern_let(msrc: &str, blobstart: Point, blobend: Point,
                      searchstr: &str, filepath: &Path, search_type: SearchType,
                      local: bool, pattern: &str, mtype: MatchType) -> Vec<Match> {
     let mut out = Vec::new();
@@ -184,28 +184,28 @@ fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
     out
 }
 
-pub fn match_if_let(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_if_let(msrc: &str, blobstart: Point, blobend: Point,
                     searchstr: &str, filepath: &Path, search_type: SearchType,
                     local: bool) -> Vec<Match> {
     match_pattern_let(msrc, blobstart, blobend, searchstr, filepath,
                       search_type, local, "if let ", IfLet)
 }
 
-pub fn match_while_let(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_while_let(msrc: &str, blobstart: Point, blobend: Point,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
                  local: bool) -> Vec<Match> {
     match_pattern_let(msrc, blobstart, blobend, searchstr, filepath,
                       search_type, local, "while let ", WhileLet)
 }
 
-pub fn match_let(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_let(msrc: &str, blobstart: Point, blobend: Point,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
                  local: bool) -> Vec<Match> {
     match_pattern_let(msrc, blobstart, blobend, searchstr, filepath,
                       search_type, local, "let ", Let)
 }
 
-pub fn match_for(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_for(msrc: &str, blobstart: Point, blobend: Point,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
                  local: bool) -> Vec<Match> {
     let mut out = Vec::new();
@@ -246,7 +246,7 @@ pub fn get_context(blob: &str, context_end: &str) -> String {
         .join(" ")
 }
 
-pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_extern_crate(msrc: &str, blobstart: Point, blobend: Point,
                           searchstr: &str, filepath: &Path, search_type: SearchType,
                           session: &Session) -> Option<Match> {
     let mut res = None;
@@ -294,7 +294,7 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
     res
 }
 
-pub fn match_mod(msrc: Src, blobstart: usize, blobend: usize,
+pub fn match_mod(msrc: Src, blobstart: Point, blobend: Point,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
                  local: bool, session: &Session) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -369,7 +369,7 @@ pub fn match_mod(msrc: Src, blobstart: usize, blobend: usize,
     None
 }
 
-pub fn match_struct(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_struct(msrc: &str, blobstart: Point, blobend: Point,
                     searchstr: &str, filepath: &Path, search_type: SearchType,
                     local: bool) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -409,7 +409,7 @@ pub fn match_struct(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
-pub fn match_type(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_type(msrc: &str, blobstart: Point, blobend: Point,
                   searchstr: &str, filepath: &Path, search_type: SearchType,
                   local: bool) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -436,7 +436,7 @@ pub fn match_type(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
-pub fn match_trait(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_trait(msrc: &str, blobstart: Point, blobend: Point,
                    searchstr: &str, filepath: &Path, search_type: SearchType,
                    local: bool) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -463,7 +463,7 @@ pub fn match_trait(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
-pub fn match_enum_variants(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_enum_variants(msrc: &str, blobstart: Point, blobend: Point,
                            searchstr: &str, filepath: &Path, search_type: SearchType,
                            local: bool) -> vec::IntoIter<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -494,7 +494,7 @@ pub fn match_enum_variants(msrc: &str, blobstart: usize, blobend: usize,
     out.into_iter()
 }
 
-pub fn match_enum(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_enum(msrc: &str, blobstart: Point, blobend: Point,
                   searchstr: &str, filepath: &Path, search_type: SearchType,
                   local: bool) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -526,7 +526,7 @@ pub fn match_enum(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
-pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_use(msrc: &str, blobstart: Point, blobend: Point,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
                  local: bool, session: &Session,
                  pending_imports: &PendingImports) -> Vec<Match> {
@@ -635,7 +635,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
     out
 }
 
-pub fn match_fn(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_fn(msrc: &str, blobstart: Point, blobend: Point,
                 searchstr: &str, filepath: &Path, search_type: SearchType,
                 local: bool) -> Option<Match> {
 
@@ -670,7 +670,7 @@ pub fn match_fn(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
-pub fn match_macro(msrc: &str, blobstart: usize, blobend: usize,
+pub fn match_macro(msrc: &str, blobstart: Point, blobend: Point,
                    searchstr: &str, filepath: &Path, search_type: SearchType,
                    local: bool) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
@@ -700,7 +700,7 @@ pub fn match_macro(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
-pub fn find_doc(msrc: &str, match_point: usize) -> String {
+pub fn find_doc(msrc: &str, match_point: Point) -> String {
     let blob = &msrc[0..match_point];
 
     blob.lines()
@@ -717,7 +717,7 @@ pub fn find_doc(msrc: &str, match_point: usize) -> String {
         .join("\n")
 }
 
-fn find_mod_doc(msrc: &str, blobstart: usize) -> String {
+fn find_mod_doc(msrc: &str, blobstart: Point) -> String {
     let blob = &msrc[blobstart..];
     let mut doc = String::new();
 

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -2,7 +2,7 @@
 
 use {core, ast, matchers, scopes, typeinf};
 use core::SearchType::{self, ExactMatch, StartsWith};
-use core::{Match, Src, Session, Coordinate, SessionExt, Ty};
+use core::{Match, Src, Session, Coordinate, SessionExt, Ty, Point};
 use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField, Impl, TraitImpl, MatchArm, Builtin};
 use core::Namespace;
 use util::{symbol_matches, txt_matches, find_ident_end};
@@ -53,7 +53,7 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
 }
 
 pub fn search_for_impl_methods(match_request: &Match,
-                           fieldsearchstr: &str, point: usize,
+                           fieldsearchstr: &str, point: Point,
                            fpath: &Path, local: bool,
                            search_type: SearchType,
                                session: &Session) -> vec::IntoIter<Match> {
@@ -114,7 +114,7 @@ pub fn search_for_impl_methods(match_request: &Match,
     out.into_iter()
 }
 
-fn search_scope_for_methods(point: usize, src: Src, searchstr: &str, filepath: &Path,
+fn search_scope_for_methods(point: Point, src: Src, searchstr: &str, filepath: &Path,
                             search_type: SearchType) -> vec::IntoIter<Match> {
     debug!("searching scope for methods {} |{}| {:?}", point, searchstr, filepath.display());
 
@@ -152,7 +152,7 @@ fn search_scope_for_methods(point: usize, src: Src, searchstr: &str, filepath: &
     out.into_iter()
 }
 
-fn search_generic_impl_scope_for_methods(point: usize, src: Src, searchstr: &str, contextm: &Match,
+fn search_generic_impl_scope_for_methods(point: Point, src: Src, searchstr: &str, contextm: &Match,
                             search_type: SearchType) -> vec::IntoIter<Match> {
     debug!("searching generic impl scope for methods {} |{}| {:?}", point, searchstr, contextm.filepath.display());
 
@@ -190,7 +190,7 @@ fn search_generic_impl_scope_for_methods(point: usize, src: Src, searchstr: &str
     out.into_iter()
 }
 
-fn search_scope_for_method_declarations(point: usize, src: Src, searchstr: &str, filepath: &Path,
+fn search_scope_for_method_declarations(point: Point, src: Src, searchstr: &str, filepath: &Path,
                             search_type: SearchType) -> vec::IntoIter<Match> {
     debug!("searching scope for method declarations {} |{}| {:?}", point, searchstr, filepath.display());
 
@@ -229,7 +229,7 @@ fn search_scope_for_method_declarations(point: usize, src: Src, searchstr: &str,
 }
 
 
-pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: bool, include_traits: bool,
+pub fn search_for_impls(pos: Point, searchstr: &str, filepath: &Path, local: bool, include_traits: bool,
                         session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_for_impls {}, {}, {:?}", pos, searchstr, filepath.display());
     let s = session.load_file(filepath);
@@ -313,7 +313,7 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
     out.into_iter()
 }
 
-pub fn search_for_generic_impls(pos: usize, searchstr: &str, contextm: &Match, filepath: &Path, session: &Session) -> vec::IntoIter<Match> {
+pub fn search_for_generic_impls(pos: Point, searchstr: &str, contextm: &Match, filepath: &Path, session: &Session) -> vec::IntoIter<Match> {
     debug!("search_for_generic_impls {}, {}, {:?}", pos, searchstr, filepath.display());
     let s = session.load_file(filepath);
     let scope_start = scopes::scope_start(s.as_src(), pos);
@@ -376,7 +376,7 @@ pub fn search_for_generic_impls(pos: usize, searchstr: &str, contextm: &Match, f
 }
 
 // scope headers include fn decls, if let, while let etc..
-fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &str,
+fn search_scope_headers(point: Point, scopestart: Point, msrc: Src, searchstr: &str,
                         filepath: &Path, search_type: SearchType, session: &Session,
                         pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_scope_headers for |{}| pt: {}", searchstr, scopestart);
@@ -524,7 +524,7 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
     Vec::new().into_iter()
 }
 
-fn mask_matchstmt(matchstmt_src: &str, innerscope_start: usize) -> String {
+fn mask_matchstmt(matchstmt_src: &str, innerscope_start: Point) -> String {
     let s = scopes::mask_sub_scopes(&matchstmt_src[innerscope_start..]);
     matchstmt_src[..innerscope_start].to_owned() + &s
 }
@@ -539,7 +539,7 @@ fn does_it() {
     debug!("PHIL res is |{}|",res);
 }
 
-fn search_fn_args(fnstart: usize, open_brace_pos: usize, msrc: &str,
+fn search_fn_args(fnstart: Point, open_brace_pos: Point, msrc: &str,
                   searchstr: &str, filepath: &Path,
                   search_type: SearchType, local: bool) -> vec::IntoIter<Match> {
     let mut out = Vec::new();
@@ -708,7 +708,7 @@ pub fn find_possible_crate_root_modules(currentdir: &Path, session: &Session) ->
     res
 }
 
-pub fn search_next_scope(mut startpoint: usize, pathseg: &core::PathSegment,
+pub fn search_next_scope(mut startpoint: Point, pathseg: &core::PathSegment,
                          filepath:&Path, search_type: SearchType, local: bool,
                          namespace: Namespace, session: &Session,
                          pending_imports: &PendingImports) -> vec::IntoIter<Match> {
@@ -773,7 +773,7 @@ pub fn get_module_file(name: &str, parentdir: &Path, session: &Session) -> Optio
     None
 }
 
-pub fn search_scope(start: usize, point: usize, src: Src,
+pub fn search_scope(start: Point, point: Point, src: Src,
                     pathseg: &core::PathSegment,
                     filepath:&Path, search_type: SearchType, local: bool,
                     namespace: Namespace,
@@ -944,7 +944,7 @@ pub fn search_scope(start: usize, point: usize, src: Src,
     out.into_iter()
 }
 
-fn try_to_match_closure_definition(searchstr: &str, scope_src: &str, scope_src_pos: usize, filepath: &Path) -> Option<Match> {
+fn try_to_match_closure_definition(searchstr: &str, scope_src: &str, scope_src_pos: Point, filepath: &Path) -> Option<Match> {
     if searchstr.is_empty() {
         return None;
     }
@@ -969,7 +969,7 @@ fn try_to_match_closure_definition(searchstr: &str, scope_src: &str, scope_src_p
     }
 }
 
-fn run_matchers_on_blob(src: Src, start: usize, end: usize, searchstr: &str,
+fn run_matchers_on_blob(src: Src, start: Point, end: Point, searchstr: &str,
                         filepath: &Path, search_type: SearchType, local: bool,
                         namespace: Namespace, session: &Session,
                         pending_imports: &PendingImports) -> Vec<Match> {
@@ -1016,7 +1016,7 @@ fn run_matchers_on_blob(src: Src, start: usize, end: usize, searchstr: &str,
 }
 
 fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
-                       msrc: Src, point: usize, search_type: SearchType,
+                       msrc: Src, point: Point, search_type: SearchType,
                        namespace: Namespace, session: &Session,
                        pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_local_scopes {:?} {:?} {} {:?} {:?}", pathseg, filepath.display(), point,
@@ -1082,7 +1082,7 @@ pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
     out.into_iter()
 }
 
-pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
+pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: Point,
                                    search_type: SearchType, namespace: Namespace,
                                    session: &Session) -> vec::IntoIter<Match> {
     debug!("resolve_path_with_str {:?}", path);
@@ -1126,10 +1126,10 @@ pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
 pub struct Search {
     path: Vec<String>,
     filepath: String,
-    pos: usize
+    pos: Point
 }
 
-pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
+pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: Point,
                     search_type: SearchType, namespace: Namespace,
                     session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     let mut out = Vec::new();
@@ -1207,7 +1207,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
 }
 
 // Get the scope corresponding to super::
-pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session,
+pub fn get_super_scope(filepath: &Path, pos: Point, session: &Session,
                        pending_imports: &PendingImports) -> Option<core::Scope> {
     let msrc = session.load_file_and_mask_comments(filepath);
     let mut path = scopes::get_local_module_path(msrc.as_src(), pos);
@@ -1243,7 +1243,7 @@ pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session,
     }
 }
 
-pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
+pub fn resolve_path(path: &core::Path, filepath: &Path, pos: Point,
                     search_type: SearchType, namespace: Namespace,
                     session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("resolve_path {:?} {:?} {} {:?}", path, filepath.display(), pos, search_type);
@@ -1350,7 +1350,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
     }
 }
 
-pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_type: SearchType, namespace: Namespace,
+pub fn do_external_search(path: &[&str], filepath: &Path, pos: Point, search_type: SearchType, namespace: Namespace,
                           session: &Session) -> vec::IntoIter<Match> {
     debug!("do_external_search path {:?} {:?}", path, filepath.display());
     let mut out = Vec::new();

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -67,7 +67,7 @@ pub fn find_stmt_start(msrc: Src, point: Point) -> Option<Point> {
 }
 
 /// Finds a statement start or panics.
-pub fn expect_stmt_start(msrc: Src, point: usize) -> usize {
+pub fn expect_stmt_start(msrc: Src, point: Point) -> Point {
     find_stmt_start(msrc, point).expect("Statement has a beginning")
 }
 

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,5 +1,5 @@
 use {ast, typeinf, util};
-use core::{Src, CompletionType};
+use core::{Src, CompletionType, Point, SourceRange};
 #[cfg(test)]
 use core::{self, Coordinate};
 
@@ -9,7 +9,7 @@ use std::str::from_utf8;
 use util::char_at;
 use regex::Regex;
 
-fn find_close<'a, A>(iter: A, open: u8, close: u8, level_end: u32) -> Option<usize> where A: Iterator<Item=&'a u8> {
+fn find_close<'a, A>(iter: A, open: u8, close: u8, level_end: u32) -> Option<Point> where A: Iterator<Item=&'a u8> {
     let mut levels = 0u32;
     for (count, &b) in iter.enumerate() {
         if b == close {
@@ -21,12 +21,12 @@ fn find_close<'a, A>(iter: A, open: u8, close: u8, level_end: u32) -> Option<usi
     None
 }
 
-pub fn find_closing_paren(src: &str, pos: usize) -> usize {
+pub fn find_closing_paren(src: &str, pos: Point) -> Point {
     find_close(src.as_bytes()[pos..].iter(), b'(', b')', 0)
     .map_or(src.len(), |count| pos + count)
 }
 
-pub fn find_closure_scope_start(src: Src, point: usize, parentheses_open_pos: usize) -> Option<usize> {
+pub fn find_closure_scope_start(src: Src, point: Point, parentheses_open_pos: Point) -> Option<Point> {
     let masked_src = mask_comments(src.from(point));
 
     let closing_paren_pos = find_closing_paren(masked_src.as_str(), 0) + point;
@@ -40,7 +40,7 @@ pub fn find_closure_scope_start(src: Src, point: usize, parentheses_open_pos: us
     }
 }
 
-pub fn scope_start(src: Src, point: usize) -> usize {
+pub fn scope_start(src: Src, point: Point) -> Point {
     let masked_src = mask_comments(src.to(point));
 
     let curly_parent_open_pos = find_close(masked_src.as_bytes().iter().rev(), b'}', b'{', 0)
@@ -58,7 +58,7 @@ pub fn scope_start(src: Src, point: usize) -> usize {
     }
 }
 
-pub fn find_stmt_start(msrc: Src, point: usize) -> Option<usize> {
+pub fn find_stmt_start(msrc: Src, point: Point) -> Option<Point> {
     // iterate the scope to find the start of the statement
     let scopestart = scope_start(msrc, point);
     msrc.from(scopestart).iter_stmts()
@@ -68,7 +68,7 @@ pub fn find_stmt_start(msrc: Src, point: usize) -> Option<usize> {
 
 /// Finds the start of a `let` statement; includes handling of struct pattern matches in the
 /// statement.
-pub fn find_let_start(msrc: Src, point: usize) -> Option<usize> {
+pub fn find_let_start(msrc: Src, point: Point) -> Option<Point> {
     let mut scopestart = scope_start(msrc, point);
     let mut let_start = None;
 
@@ -96,13 +96,13 @@ pub fn find_let_start(msrc: Src, point: usize) -> Option<usize> {
     let_start.map(|(start, _)| scopestart + start)
 }
 
-pub fn get_local_module_path(msrc: Src, point: usize) -> Vec<String> {
+pub fn get_local_module_path(msrc: Src, point: Point) -> Vec<String> {
     let mut v = Vec::new();
     get_local_module_path_(msrc, point, &mut v);
     v
 }
 
-fn get_local_module_path_(msrc: Src, point: usize, out: &mut Vec<String>) {
+fn get_local_module_path_(msrc: Src, point: Point, out: &mut Vec<String>) {
     for (start, end) in msrc.iter_stmts() {
         if start < point && end > point {
             let blob = msrc.from_to(start, end);
@@ -119,7 +119,7 @@ fn get_local_module_path_(msrc: Src, point: usize, out: &mut Vec<String>) {
     }
 }
 
-pub fn get_module_file_from_path(msrc: Src, point: usize, parentdir: &Path) -> Option<PathBuf> {
+pub fn get_module_file_from_path(msrc: Src, point: Point, parentdir: &Path) -> Option<PathBuf> {
     let mut iter = msrc.iter_stmts();
     while let Some((start, end)) = iter.next() {
         let blob = msrc.from_to(start, end);
@@ -142,7 +142,7 @@ pub fn get_module_file_from_path(msrc: Src, point: usize, parentdir: &Path) -> O
     None
 }
 
-pub fn find_impl_start(msrc: Src, point: usize, scopestart: usize) -> Option<usize> {
+pub fn find_impl_start(msrc: Src, point: Point, scopestart: Point) -> Option<Point> {
     let len = point-scopestart;
     match msrc.from(scopestart).iter_stmts().find(|&(_, end)| end > len) {
         Some((start, _)) => {
@@ -191,7 +191,7 @@ pub fn split_into_context_and_completion(s: &str) -> (&str, &str, CompletionType
     }
 }
 
-pub fn get_line(src: &str, point: usize) -> usize {
+pub fn get_line(src: &str, point: Point) -> Point {
     let mut i = point;
     for &b in src.as_bytes()[..point].iter().rev() {
         i-=1;
@@ -204,7 +204,7 @@ pub fn get_line(src: &str, point: usize) -> usize {
 
 /// search in reverse for the start of the current expression 
 /// allow . and :: to be surrounded by white chars to enable multi line call chains 
-pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {
+pub fn get_start_of_search_expr(src: &str, point: Point) -> Point {
 
     enum State {
         Levels(usize),
@@ -212,7 +212,7 @@ pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {
         MustEndsWithDot(usize),
         StartsWithCol(usize),
         None,
-        Result(usize),
+        Result(Point),
     }
     let mut ws_ok = State::None;
     for (i, c) in src.as_bytes()[..point].iter().enumerate().rev() {
@@ -247,7 +247,7 @@ pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {
     0
 }
 
-pub fn get_start_of_pattern(src: &str, point: usize) -> usize {
+pub fn get_start_of_pattern(src: &str, point: Point) -> Point {
     let mut i = point-1;
     let mut levels = 0u32;
     for &b in src.as_bytes()[..point].iter().rev() {
@@ -279,7 +279,7 @@ fn get_start_of_pattern_handles_variant2() {
     assert_eq!(4, get_start_of_pattern("bla, ast::PatTup(ref tuple_elements) => {",36));
 }
 
-pub fn expand_search_expr(msrc: &str, point: usize) -> (usize, usize) {
+pub fn expand_search_expr(msrc: &str, point: Point) -> SourceRange {
     let start = get_start_of_search_expr(msrc, point);
     (start, util::find_ident_end(msrc, point))
 }

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,5 +1,5 @@
 use {ast, typeinf, util};
-use core::{Src, CompletionType, Point, SourceRange};
+use core::{Src, CompletionType, Point, SourceByteRange};
 #[cfg(test)]
 use core::{self, Coordinate};
 
@@ -292,7 +292,7 @@ fn get_start_of_pattern_handles_variant2() {
     assert_eq!(4, get_start_of_pattern("bla, ast::PatTup(ref tuple_elements) => {",36));
 }
 
-pub fn expand_search_expr(msrc: &str, point: Point) -> SourceRange {
+pub fn expand_search_expr(msrc: &str, point: Point) -> SourceByteRange {
     let start = get_start_of_search_expr(msrc, point);
     (start, util::find_ident_end(msrc, point))
 }

--- a/src/racer/testutils.rs
+++ b/src/racer/testutils.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use core::SourceRange;
+use core::SourceByteRange;
 
 #[cfg(test)]
 pub fn rejustify(src: &str) -> String {
@@ -18,6 +18,6 @@ pub fn rejustify(src: &str) -> String {
 }
 
 #[cfg(test)]
-pub fn slice(src: &str, (begin, end): SourceRange) -> &str {
+pub fn slice(src: &str, (begin, end): SourceByteRange) -> &str {
     &src[begin..end]
 }

--- a/src/racer/testutils.rs
+++ b/src/racer/testutils.rs
@@ -1,4 +1,7 @@
 #[cfg(test)]
+use core::SourceRange;
+
+#[cfg(test)]
 pub fn rejustify(src: &str) -> String {
     let s = &src[1..]; // remove the newline
     let mut sb = String::new();
@@ -15,6 +18,6 @@ pub fn rejustify(src: &str) -> String {
 }
 
 #[cfg(test)]
-pub fn slice(src: &str, (begin, end): (usize, usize)) -> &str {
+pub fn slice(src: &str, (begin, end): SourceRange) -> &str {
     &src[begin..end]
 }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -1,6 +1,6 @@
 // Type inference
 
-use core::{Match, Src, Scope, Session, SessionExt};
+use core::{Match, Src, Scope, Session, SessionExt, Point};
 use nameres::resolve_path_with_str;
 use core::Namespace;
 use core;
@@ -11,7 +11,7 @@ use core::SearchType::ExactMatch;
 use util::txt_matches;
 use std::path::Path;
 
-fn find_start_of_function_body(src: &str) -> usize {
+fn find_start_of_function_body(src: &str) -> Point {
     // TODO: this should ignore anything inside parens so as to skip the arg list
     src.find('{').unwrap()
 }
@@ -82,7 +82,7 @@ fn get_type_of_self_arg(m: &Match, msrc: Src, session: &Session) -> Option<core:
     get_type_of_self(m.point, &m.filepath, m.local, msrc, session)
 }
 
-pub fn get_type_of_self(point: usize, filepath: &Path, local: bool, msrc: Src, session: &Session) -> Option<core::Ty> {
+pub fn get_type_of_self(point: Point, filepath: &Path, local: bool, msrc: Src, session: &Session) -> Option<core::Ty> {
     scopes::find_impl_start(msrc, point, 0).and_then(|start| {
         let decl = generate_skeleton_for_parsing(&msrc.from(start));
         debug!("get_type_of_self_arg impl skeleton |{}|", decl);

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use std::path;
 use std::rc::Rc;
 
-use core::{IndexedSource, Session, SessionExt, Location, LocationExt};
+use core::{IndexedSource, Session, SessionExt, Location, LocationExt, Point};
 
 use core::SearchType::{self, ExactMatch, StartsWith};
 
@@ -156,8 +156,8 @@ pub fn expand_ident<P, C>(
 
 pub struct ExpandedIdent {
     src: Rc<IndexedSource>,
-    start: usize,
-    pos: usize,
+    start: Point,
+    pos: Point,
 }
 
 impl ExpandedIdent {
@@ -165,16 +165,16 @@ impl ExpandedIdent {
         &self.src.code[self.start..self.pos]
     }
 
-    pub fn start(&self) -> usize {
+    pub fn start(&self) -> Point {
         self.start
     }
 
-    pub fn pos(&self) -> usize {
+    pub fn pos(&self) -> Point {
         self.pos
     }
 }
 
-pub fn find_ident_end(s: &str, pos: usize) -> usize {
+pub fn find_ident_end(s: &str, pos: Point) -> Point {
     // find end of word
     let sa = &s[pos..];
     for (i, c) in sa.char_indices() {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::thread;
 
-use racer::{complete_from_file, find_definition, Match, MatchType, Coordinate};
+use racer::{complete_from_file, find_definition, Match, MatchType, Coordinate, Point};
 
 lazy_static! {
     static ref SYNC: Mutex<u8> = { Mutex::new(0) };
@@ -149,7 +149,7 @@ impl Drop for TmpDir {
     }
 }
 
-fn get_pos_and_source(src: &str) -> (usize, String) {
+fn get_pos_and_source(src: &str) -> (Point, String) {
     let point = src.find('~').unwrap();
     (point, src.replace('~', ""))
 }


### PR DESCRIPTION
Throughout the code `usize` is used for line numbers, column numbers, tuple indexes, and source points. For a new contributor, this makes it harder to read the code and be confident in what's happening. 

* `core::Point` is an alias for `usize` when it's used as a source position.
* `core::SourceRange` is an alias for `(usize, usize)` when that is a range in source text.

This PR uses type aliases rather than newtypes to avoid any perf or compatibility risks. Replacements were made by hand to ensure that `usize` was still used when not referring to a point.