### PR TITLE
Be stricter about deciding what constitutes a closure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ doc = false
 debug = true
 
 [dependencies]
+lazy_static = "0.2"
 log = "0.3.6"
 syntex_syntax = "0.52.0"
 syntex_errors = "0.52.0"
@@ -36,7 +37,6 @@ optional = true
 
 [dev-dependencies]
 rand = "0.3"
-lazy_static = "0.2"
 
 [features]
 nightly = []

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "clippy", allow(clippy))]
 #![cfg_attr(all(feature = "clippy", not(test)), deny(print_stdout))]
 
+#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 
 extern crate syntex_syntax;

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -834,7 +834,8 @@ pub fn search_scope(start: usize, point: usize, src: Src,
             }
         }
     }
-    // now search from top of scope for items etc..
+
+    // since we didn't find a `let` binding, now search from top of scope for items etc..
     let mut codeit = v.into_iter().chain(codeit);
     for (blobstart, blobend) in &mut codeit {
         // sometimes we need to skip blocks of code if the preceeding attribute disables it
@@ -949,21 +950,58 @@ fn try_to_match_closure_definition(searchstr: &str, scope_src: &str, scope_src_p
         return None;
     }
 
-    if let Some(cap) = Regex::new(format!(r"(?:\|)(?:(?s).*,[^a-zA-Z0-9]*|[^a-zA-Z0-9]*)?(?P<definition>{})(?:[^a-zA-Z0-9\|]+[^\|]*)?(?:\|)",
-                                          searchstr).as_str()).unwrap().captures(scope_src) {
-        let def = cap.name("definition").unwrap();
-        Some(Match {
-            matchstr: searchstr.to_owned(),
-            filepath: filepath.to_path_buf(),
-            point: def.start() + scope_src_pos,
-            coords: None,
-            local: true,
-            mtype: FnArg,
-            contextstr: cap.get(0).unwrap().as_str().to_owned(),
-            generic_args: Vec::new(),
-            generic_types: Vec::new(),
-            docs: String::new(),
-        })
+    /// Search for a closure declaration (defined here as "stuff bracketed by | characters").
+    ///
+    /// The pipe characters are preserved by the capture as their presence for some reason
+    /// prevents bad matches on type annotations.
+    ///
+    /// TODO: properly look for closures by requiring it not be after an expression.
+    let closure_decl = Regex::new(r"\|[^;]*?\|").unwrap();
+
+    trace!("Closure definition match is looking for `{}` in {} characters", searchstr, scope_src.len());
+
+    if let Some(cap) = closure_decl.captures(scope_src) {
+        /// This regex looks for the passed-in ident surrounded by non-ident characters
+        /// on the left side of a colon (if one is present). It takes as input the declaration
+        /// of a closure's arguments.
+        let ident_in_closure = Regex::new(&format!(r"(?x:
+            \|
+            (?:(?s).*,[^a-zA-Z0-9]*|[^a-zA-Z0-9]*)? # discard things before the identifier
+            (?P<definition>{})
+            (?:[^a-zA-Z0-9\|]+[^\|;]*)?
+            \|
+        )", searchstr)).unwrap();
+
+        let decl = cap.get(0).unwrap();
+
+        trace!("Found a closure declaration {}..{}, about to search for `{}` in {}", 
+            decl.start(), 
+            decl.end(), 
+            searchstr, 
+            decl.as_str().trim()
+        );
+
+        if let Some(ident_match) = ident_in_closure.captures(decl.as_str()) {
+
+            let def = ident_match.name("definition").unwrap();
+    
+            trace!("Closure definition matched by {}..{}: {:?}", def.start(), def.end(), &cap[0]);
+
+            Some(Match {
+                matchstr: searchstr.to_owned(),
+                filepath: filepath.to_path_buf(),
+                point: def.start() + scope_src_pos,
+                coords: None,
+                local: true,
+                mtype: FnArg,
+                contextstr: cap.get(0).unwrap().as_str().to_owned(),
+                generic_args: Vec::new(),
+                generic_types: Vec::new(),
+                docs: String::new(),
+            })
+        } else {
+            None
+        }
     } else {
         None
     }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -956,11 +956,13 @@ fn try_to_match_closure_definition(searchstr: &str, scope_src: &str, scope_src_p
     /// prevents bad matches on type annotations.
     ///
     /// TODO: properly look for closures by requiring it not be after an expression.
-    let closure_decl = Regex::new(r"\|[^;]*?\|").unwrap();
+    lazy_static! {
+        static ref CLOSURE_DECL: Regex = Regex::new(r"\|[^;]*?\|").unwrap();
+    }
 
     trace!("Closure definition match is looking for `{}` in {} characters", searchstr, scope_src.len());
 
-    if let Some(cap) = closure_decl.captures(scope_src) {
+    if let Some(cap) = CLOSURE_DECL.captures(scope_src) {
         /// This regex looks for the passed-in ident surrounded by non-ident characters
         /// on the left side of a colon (if one is present). It takes as input the declaration
         /// of a closure's arguments.

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2908,6 +2908,46 @@ fn ignores_impl_macro() {
 }
 
 #[test]
+fn closure_scope_dont_match_type_annotations() {
+    let _lock = sync!();
+    let src = "
+    struct Foo;
+    fn main() {
+        let y = Some(Foo);
+        y.map(|x: Foo| Fo~o);
+    }
+    ";
+
+    let got = get_definition(src, None);
+    println!("{:?}", got);
+    assert_eq!(MatchType::Struct, got.mtype);
+    assert_eq!(2, got.coords.unwrap().line);
+}
+
+/// The variable `i` doesn't exist in `foo`, so trying to get the definition should
+/// fail.
+#[test]
+#[should_panic]
+fn closure_scope_dont_match_bitwise_or() {
+    let _lock = sync!();
+    let src = "
+    fn foo() {
+        i~
+    }
+    fn bar() {
+        let i = 0;
+        let x = 0 | i;
+    }
+    fn baz() {
+        // 1 || 2;
+    }
+    ";
+
+    let got = get_definition(src, None);
+    println!("Unexpectedly found definition: {:?}", got);
+}
+
+#[test]
 fn closure_scope_find_outside() {
     let _lock = sync!();
 


### PR DESCRIPTION
This fixes #732 by separating the "look for a closure declaration" from "look for ident inside closure parameters". It's probably still not optimal, but it passes the new tests and seems accurate in my local usage.

@bkchr, please have a look at the regexes.