### PR TITLE
Replace `unwrap` with `expect` in racer::typeinf

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -21,8 +21,8 @@ pub const PATH_SEP: char = ';';
 fn search_struct_fields(searchstr: &str, structmatch: &Match,
                         search_type: SearchType, session: &Session) -> vec::IntoIter<Match> {
     let src = session.load_file(&structmatch.filepath);
-    let opoint = scopes::find_stmt_start(src.as_src(), structmatch.point);
-    let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
+    let opoint = scopes::expect_stmt_start(src.as_src(), structmatch.point);
+    let structsrc = scopes::end_of_next_scope(&src[opoint..]);
 
     let fields = ast::parse_struct_fields(structsrc.to_owned(),
                                           core::Scope::from_match(structmatch));
@@ -38,7 +38,7 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
             };
             out.push(Match { matchstr: field,
                                 filepath: structmatch.filepath.clone(),
-                                point: fpos + opoint.unwrap(),
+                                point: fpos + opoint,
                                 coords: None,
                                 local: structmatch.local,
                                 mtype: StructField,

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -66,6 +66,11 @@ pub fn find_stmt_start(msrc: Src, point: usize) -> Option<usize> {
         .map(|(start, _)| scopestart + start)
 }
 
+/// Finds a statement start or panics.
+pub fn expect_stmt_start(msrc: Src, point: usize) -> usize {
+    find_stmt_start(msrc, point).expect("Statement has a beginning")
+}
+
 /// Finds the start of a `let` statement; includes handling of struct pattern matches in the
 /// statement.
 pub fn find_let_start(msrc: Src, point: usize) -> Option<usize> {


### PR DESCRIPTION
Replaced a bunch of `unwrap` calls with more descriptive `expect` statements.

Also added a new public function `scopes::expect_stmt_start` to avoid repeating the same error in lots of places.