### PR TITLE
Search for functions on enums in addition to finding variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Change Log
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Find static methods on enums #737
+
 ## 2.0.8
 
 - Fix bug finding definitions where impl contains bang #717

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1684,6 +1684,33 @@ fn finds_enum_static_method() {
 }
 
 #[test]
+fn finds_enum_variants_first() {
+    let _lock = sync!();
+    let src = "
+    enum Foo {
+        Bar,
+        Baz
+    }
+
+    impl Foo {
+        pub fn amazing() -> Self {
+            Foo::Baz
+        }
+    }
+
+    fn myfn() -> Foo {
+        Foo::~Bar
+    }
+    ";
+
+    let got = get_all_completions(src, None);
+    assert_eq!(3, got.len());
+    assert_eq!("Bar", got[0].matchstr);
+    assert_eq!("Baz", got[1].matchstr);
+    assert_eq!("amazing", got[2].matchstr);
+}
+
+#[test]
 fn follows_let_method_call() {
     let _lock = sync!();
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1659,6 +1659,31 @@ fn follows_arg_to_enum_method() {
 }
 
 #[test]
+fn finds_enum_static_method() {
+    let _lock = sync!();
+    let src = "
+    enum Foo {
+        Bar,
+        Baz
+    }
+
+    impl Foo {
+        pub fn make_baz() -> Self {
+            Foo::Baz
+        }
+    }
+
+    fn myfn() -> Foo {
+        Foo::ma~ke_baz()
+    }
+    ";
+
+    let got = get_only_completion(src, None);
+    assert_eq!("make_baz", got.matchstr);
+    assert_eq!(MatchType::Function, got.mtype);
+}
+
+#[test]
 fn follows_let_method_call() {
     let _lock = sync!();
 


### PR DESCRIPTION
Previously, racer would _only_ return enum variants. However, enums are also allowed to have `impl` blocks and can declare static functions. This change uses the struct search code on enums, and will always return variants followed by impl functions.