### PR TITLE
Find doc strings for named and tuple struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Find static methods on enums #737
 - Find methods on cooked string literals #728
-- Find doc comments on named and indexed struct fields
+- Find doc comments on named and indexed struct fields #739
 
 ## 2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Find static methods on enums #737
 - Find methods on cooked string literals #728
+- Find doc comments on named and indexed struct fields
 
 ## 2.0.8
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -250,6 +250,49 @@ fn finds_struct_docs() {
 }
 
 #[test]
+fn finds_struct_field_docs() {
+    let _lock = sync!();
+
+    let src = "
+    struct Foo {
+        /// Hello docs
+        ///
+        /// How are you?
+        #[allow(dead_code)]
+        hello: String,
+    }
+
+    fn do_things(f: Foo) -> String {
+        f.h~ello.clone()
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("hello", got.matchstr);
+    assert_eq!("Hello docs\n\nHow are you?", got.docs);
+}
+
+#[test]
+fn finds_tuple_struct_field_docs() {
+    let _lock = sync!();
+
+    let src = "
+    struct Bar(
+        /// Hello docs
+        String
+    );
+
+    fn do_things(b: Bar) -> String {
+        b.~0.clone()
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("0", got.matchstr);
+    assert_eq!("Hello docs", got.docs);
+}
+
+#[test]
 fn completes_fn_with_substitute_file() {
     let _lock = sync!();
 
@@ -1244,6 +1287,7 @@ fn completes_struct_field_via_assignment() {
 
     let src = "
     struct Point {
+        /// The first item.
         first: f64,
         second: f64
     }
@@ -1254,6 +1298,7 @@ fn completes_struct_field_via_assignment() {
 
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "first");
+    assert_eq!("The first item.", got.docs);
 }
 
 #[test]
@@ -1262,6 +1307,7 @@ fn finds_defn_of_struct_field() {
 
     let src = "
     struct Point {
+        /// The first item.
         first: f64,
         second: f64
     }
@@ -1272,6 +1318,7 @@ fn finds_defn_of_struct_field() {
 
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "first");
+    assert_eq!("The first item.", got.docs);
 }
 
 #[test]


### PR DESCRIPTION
This change uses the existing code for finding doc comments to locate docs on struct fields.