### PR TITLE
Find doc strings for `let` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Find static methods on enums #737
 - Find methods on cooked string literals #728
-- Find doc comments on named and indexed struct fields
+- Find doc comments on named and indexed struct fields #739
 
 ## 2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Find static methods on enums #737
 - Find methods on cooked string literals #728
-- Find doc comments on named and indexed struct fields #739
+- Find doc comments on struct fields and on local `let` statements #739
 
 ## 2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Find static methods on enums #737
 - Find methods on cooked string literals #728
+- Find doc comments on named and indexed struct fields
 
 ## 2.0.8
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -173,7 +173,7 @@ fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
                                    contextstr: first_line(blob),
                                    generic_args: Vec::new(),
                                    generic_types: Vec::new(),
-                                   docs: String::new(),
+                                   docs: find_doc(msrc, blobstart),
                          });
                 if let ExactMatch = search_type {
                     break;
@@ -700,6 +700,9 @@ pub fn match_macro(msrc: &str, blobstart: usize, blobend: usize,
     }
 }
 
+/// Finds outer doc comments on an object.
+/// 
+/// TODO: Support desugared #[doc=""] attributes.
 pub fn find_doc(msrc: &str, match_point: usize) -> String {
     let blob = &msrc[0..match_point];
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -416,13 +416,15 @@ fn completes_local_scope_let() {
 
     let src = "
     fn main() {
+        /// An apple's size
         let apple = 35;
         let b = ap~
     }";
 
     let got = get_one_completion(src, None);
     assert_eq!("apple", got.matchstr);
-    assert_eq!(29, got.point);
+    assert_eq!(57, got.point);
+    assert_eq!("An apple's size", got.docs);
 }
 
 #[test]
@@ -440,6 +442,7 @@ fn completes_via_parent_scope_let() {
     let got = get_one_completion(src, None);
     assert_eq!("apple", got.matchstr);
     assert_eq!(33, got.point);
+    assert_eq!("", got.docs);
 }
 
 #[test]

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -250,6 +250,49 @@ fn finds_struct_docs() {
 }
 
 #[test]
+fn finds_struct_field_docs() {
+    let _lock = sync!();
+
+    let src = "
+    struct Foo {
+        /// Hello docs
+        ///
+        /// How are you?
+        #[allow(dead_code)]
+        hello: String,
+    }
+
+    fn do_things(f: Foo) -> String {
+        f.h~ello.clone()
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("hello", got.matchstr);
+    assert_eq!("Hello docs\n\nHow are you?", got.docs);
+}
+
+#[test]
+fn finds_tuple_struct_field_docs() {
+    let _lock = sync!();
+
+    let src = "
+    struct Bar(
+        /// Hello docs
+        String
+    );
+
+    fn do_things(b: Bar) -> String {
+        b.~0.clone()
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("0", got.matchstr);
+    assert_eq!("Hello docs", got.docs);
+}
+
+#[test]
 fn completes_fn_with_substitute_file() {
     let _lock = sync!();
 
@@ -1244,6 +1287,7 @@ fn completes_struct_field_via_assignment() {
 
     let src = "
     struct Point {
+        /// The first item.
         first: f64,
         second: f64
     }
@@ -1254,6 +1298,7 @@ fn completes_struct_field_via_assignment() {
 
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "first");
+    assert_eq!("The first item.", got.docs);
 }
 
 #[test]
@@ -1262,6 +1307,7 @@ fn finds_defn_of_struct_field() {
 
     let src = "
     struct Point {
+        /// The first item.
         first: f64,
         second: f64
     }
@@ -1272,6 +1318,7 @@ fn finds_defn_of_struct_field() {
 
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "first");
+    assert_eq!("The first item.", got.docs);
 }
 
 #[test]


### PR DESCRIPTION
This adds doc finding for values defined through local `let` statements.

Flagging for @imperio, @misdreavus, @Ralith for thoughts, as it's not clear how idiomatic this behavior is in Rust today.