### PR TITLE
Support completions for pub(restricted) items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Support completion after using try operator `?` #726
 - Find methods on cooked string literals #728
 - Find doc comments on named and indexed struct fields #739
+- Find `pub(restricted)` items #748
 
 ## 2.0.8
 

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -19,6 +19,9 @@ pub fn is_ident_char(c: char) -> bool {
     c.is_alphanumeric() || (c == '_') || (c == '!')
 }
 
+/// Searches for `needle` as a standalone identifier in `haystack`. To be considered a match,
+/// the `needle` must occur either at the beginning of `haystack` or after a non-identifier
+/// character.
 pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
     match stype {
         ExactMatch => {
@@ -83,6 +86,14 @@ fn txt_matches_matches_stuff() {
     assert_eq!(true, txt_matches(StartsWith, "Vec","use Vector"));
     assert_eq!(false, txt_matches(StartsWith, "Vec","use aVector"));
     assert_eq!(true, txt_matches(ExactMatch, "Vec","use Vec"));
+}
+
+#[test]
+fn txt_matches_matches_methods() {
+    assert_eq!(true, txt_matches(StartsWith, "do_st", "fn do_stuff"));
+    assert_eq!(true, txt_matches(StartsWith, "do_st", "pub fn do_stuff"));
+    assert_eq!(true, txt_matches(StartsWith, "do_st", "pub(crate) fn do_stuff"));
+    assert_eq!(true, txt_matches(StartsWith, "do_st", "pub(in codegen) fn do_stuff"));
 }
 
 


### PR DESCRIPTION
Fixes #748 by adding `pub(restricted)` support to:

* Functions
* Struct fields
* Static methods
* Self-accepting methods