### PR TITLE
Support "use as" inside braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## HEAD
 
-- No changes, yet.
+- Support resolving `use as` aliases declared in multi-element `use` statements #753
 
 ## 2.0.9
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -595,9 +595,6 @@ pub fn match_use(msrc: &str, blobstart: Point, blobend: Point,
         let ident = use_item.ident.unwrap_or("".into());
         for path in use_item.paths.into_iter() {
             let len = path.path.segments.len();
-
-            debug!("Looking for {:?} in {:?}", searchstr, path);
-
             if symbol_matches(search_type, searchstr, &path.ident) { // i.e. 'use foo::bar as searchstr'
                 if len == 1 && path.path.segments[0].name == searchstr {
                     // is an exact match of a single use stmt.

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -942,6 +942,32 @@ fn follows_use_as() {
     assert_eq!(got.matchstr, "myfn");
 }
 
+/// Verifies fix for https://github.com/racer-rust/racer/issues/753
+#[test]
+fn follows_use_as_in_braces() {
+    let _lock = sync!();
+
+    let src = "
+        mod m {
+        pub struct Wrapper {
+            pub x: i32,
+        }
+
+        pub struct Second {
+            pub y: i32,
+        }
+    }
+
+    fn main() {
+        use m::{Wrapper as Wpr, Second};
+        let _ = W~pr { x: 1 };
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "Wrapper");
+}
+
 #[test]
 fn follows_use_glob() {
     let _lock = sync!();


### PR DESCRIPTION
This fixes #753. Doing so required changing the type of `UseVisitor`; a second commit cleaning up the naming in `match_use` is probably a good idea.