### PR TITLE
Fix #633 by looking for statement starts in path resolution

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -915,7 +915,7 @@ fn complete_from_file_(
     session: &Session
 ) -> vec::IntoIter<Match> {
     let src = session.load_file_and_mask_comments(filepath);
-    let src = &src.as_src()[..];
+    let src_text = &src.as_src()[..];
 
     // TODO return result
     let pos = match cursor.to_point(&session.load_file(filepath)) {
@@ -926,8 +926,8 @@ fn complete_from_file_(
         }
     };
 
-    let start = scopes::get_start_of_search_expr(src, pos);
-    let expr = &src[start..pos];
+    let start = scopes::get_start_of_search_expr(src_text, pos);
+    let expr = &src_text[start..pos];
 
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
@@ -942,11 +942,11 @@ fn complete_from_file_(
             // 1. The line is use contextstr::{A, B, C, searchstr
             // 2. The line started with contextstr or ::
             // 3. FIXME(may not correct): Neither above case, then expr parsed above is corrected
-            let linestart = scopes::get_line(src, pos);
+            let linestart = scopes::find_stmt_start(src.as_src(), pos).unwrap_or_else(|| scopes::get_line(src_text, pos));
 
             // step 1, get full line, take the rightmost part split by semicolon
             //   prevent the case that someone write multiple line in one line
-            let mut line = src[linestart..pos].trim().rsplit(';').nth(0).unwrap();
+            let mut line = src_text[linestart..pos].trim().rsplit(';').nth(0).unwrap();
             debug!("Complete path with line: {:?}", line);
 
             let is_global = line.starts_with("::");

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -921,6 +921,29 @@ fn follows_use() {
 }
 
 #[test]
+fn follows_use_in_braces() {
+    let _lock = sync!();
+    let src = "
+    mod foo {
+        pub fn myfn() {}
+        pub fn second() {}
+    }
+
+    fn main() {
+        use foo::{
+            myfn, 
+            second
+        };
+        
+        my~fn();
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "myfn");
+}
+
+#[test]
 fn follows_use_as() {
     let _lock = sync!();
 
@@ -2742,6 +2765,32 @@ fn completes_multiple_use_comma() {
     for (wo, wi) in gotwo.into_iter().zip(gotwi) {
         assert_eq!(wo.matchstr, wi.matchstr);
     }
+}
+
+#[test]
+fn completes_multiple_use_newline() {
+    let _lock = sync!();
+
+    let src = "
+    mod foo {
+        pub struct Bar;
+
+        pub fn myfn() {}
+    }
+
+    fn main() {
+        use foo::{
+            Bar,
+            my~fn
+        };
+
+        myfn();
+    }
+    ";
+
+    let got = get_all_completions(src, None);
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].matchstr, "myfn");
 }
 
 


### PR DESCRIPTION
This looks to address #633. That issue was the result of looking back to the start of the _line_ when performing path completions. The code was apparently under the impression that a line break could not occur inside a path. While this may be true in normal paths, newlines can occur in `use` statements.

The fix looks for the statement start when performing a path completion and then falls back to looking for the line start if it can't find a statement.

**Caution:** This seems to pass all the tests, but we don't have performance benchmarks and this change is likely to be hit in a _lot_ of cases.