### PR TITLE
Fix #763 by improving path extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## HEAD
 
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
+- Provide suggestions for global paths in more cases #765
 
 ## 2.0.9
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3563,3 +3563,48 @@ fn mod_restricted_struct_completes() {
     assert_eq!(1, got.len());
     assert_eq!("bar", got[0].matchstr);
 }
+
+#[test]
+fn completes_for_global_path_in_fn_return() {
+    let _lock = sync!();
+
+    let src = "
+    mod bar {
+        pub struct Foo;
+    }
+
+    mod baz {
+        fn foo() -> ::bar::F~oo {
+            Foo
+        }
+    }
+
+    fn main() {}
+    ";
+
+    let got = get_one_completion(src, None);
+    assert_eq!(got.matchstr, "Foo");
+}
+
+#[test]
+fn completes_for_global_path_in_trait_impl_decl() {
+    let _lock = sync!();
+
+    let src = "
+    mod foo {
+        pub trait Bar {}
+    }
+
+    mod baz {
+        pub struct Test;
+
+        impl ::foo::~Bar for Test {}
+    }
+
+    fn main() {}
+    ";
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "Bar");
+    assert_eq!(got.mtype, MatchType::Trait);
+}


### PR DESCRIPTION
Prior to this change, the determination of `is_global` for a path was made by looking at the *line* rather than the *expr*. This only worked if the line started with the path expression, which wasn't the case when global paths appeared in function signatures or impl declarations