### PR TITLE
Honor `use as` aliases when suggesting completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
 - Provide suggestions for global paths in more cases #765
+- Suggestions imported via `use as` statements now return their in-scope alias as the match string #767
 
 ## 2.0.9
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -601,7 +601,15 @@ pub fn match_use(msrc: &str, blobstart: Point, blobend: Point,
                     // Do nothing because this will be picked up by the module
                     // search in a bit.
                 } else {
-                    for m in resolve_path(path.as_ref(), filepath, blobstart, ExactMatch, Namespace::Both, session, pending_imports) {
+                    for mut m in resolve_path(path.as_ref(), filepath, blobstart, ExactMatch, Namespace::Both, session, pending_imports) {
+                        
+                        // If the match was imported by a `use as` statement, racer
+                        // should return the alias so that completions will produce
+                        // valid code.
+                        if m.matchstr != path.ident {
+                            m.matchstr = path.ident.clone();
+                        }
+
                         out.push(m);
                         if let ExactMatch = search_type  {
                             return out;

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -939,7 +939,8 @@ fn follows_use_as() {
     let dir = TmpDir::new();
     dir.write_file("src2.rs", src2);
     let got = get_definition(src, Some(dir));
-    assert_eq!(got.matchstr, "myfn");
+    assert_eq!(got.matchstr, "myfoofn");
+    assert_eq!(got.contextstr, "pub fn myfn()");
 }
 
 /// Verifies fix for https://github.com/racer-rust/racer/issues/753
@@ -965,7 +966,8 @@ fn follows_use_as_in_braces() {
     ";
 
     let got = get_definition(src, None);
-    assert_eq!(got.matchstr, "Wrapper");
+    assert_eq!(got.matchstr, "Wpr");
+    assert_eq!(got.contextstr, "pub struct Wrapper");
 }
 
 #[test]


### PR DESCRIPTION
This fixes #758 by remembering the alias and then swapping out `matchstr` in the found match with the in-scope identifier.

This change did require altering two tests, as the previous behavior here was to return the actual name, rather than the alias.