### PR TITLE
Update Travis and GitHub links to use `racer-rust`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ version = "2.0.9"
 license = "MIT"
 description = "Code completion for Rust"
 authors = ["Phil Dawes <phil@phildawes.net>"]
-homepage = "https://github.com/phildawes/racer"
-repository = "https://github.com/phildawes/racer"
+homepage = "https://github.com/racer-rust/racer"
+repository = "https://github.com/racer-rust/racer"
 
 [lib]
 name = "racer"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # *Racer* - code completion for [Rust](http://www.rust-lang.org/)
 
-[![Build Status](https://travis-ci.org/phildawes/racer.svg?branch=master)](https://travis-ci.org/phildawes/racer)
+[![Build Status](https://travis-ci.org/racer-rust/racer.svg?branch=master)](https://travis-ci.org/racer-rust/racer)
 
 ![racer completion screenshot](images/racer_completion.png)
 
@@ -20,7 +20,7 @@ As mentioned in the command output, don't forget to add the installation directo
 
 ### From sources
 
-1. Clone the repository: ```git clone https://github.com/phildawes/racer.git```
+1. Clone the repository: ```git clone https://github.com/racer-rust/racer.git```
 
 2. ```cd racer; cargo build --release```.  The binary will now be in ```./target/release/racer```
 


### PR DESCRIPTION
The racer repo moved from @phildawes' personal account to the racer-rust organization, but the URLs in the repo were never updated. This has caused the Travis badge on the project homepage not to work.