### PR TITLE
Fix mod suppression when same-name trait method exists

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,62 @@
+# Based on https://github.com/japaric/rust-everywhere/blob/master/appveyor.yml
+environment:
+  matrix:
+    # Stable channel
+    - TARGET: i686-pc-windows-gnu
+      CHANNEL: stable
+    - TARGET: i686-pc-windows-msvc
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: stable
+    # Beta channel
+    - TARGET: i686-pc-windows-gnu
+      CHANNEL: beta
+    - TARGET: i686-pc-windows-msvc
+      CHANNEL: beta
+    # Commented out because AppVeyor builds jobs serially
+    # so building all targets would be very slow.
+    # - TARGET: x86_64-pc-windows-gnu
+    #   CHANNEL: beta
+    # - TARGET: x86_64-pc-windows-msvc
+    #   CHANNEL: beta
+
+    # Nightly channel
+    - TARGET: i686-pc-windows-gnu
+      CHANNEL: nightly
+    - TARGET: i686-pc-windows-msvc
+      CHANNEL: nightly
+    # Commented out because AppVeyor builds jobs serially
+    # so building all targets would be very slow.
+    # - TARGET: x86_64-pc-windows-gnu
+    #   CHANNEL: nightly
+    # - TARGET: x86_64-pc-windows-msvc
+    #   CHANNEL: nightly
+
+# Install Rust and Cargo
+# (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe --default-host %TARGET% --default-toolchain %CHANNEL% -y
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  # the rust-src is needed for tests that depend on the standard library
+  - rustup component add rust-src
+  - set RUST_SRC_PATH=C:\Users\appveyor\.rustup\toolchains\%CHANNEL%-%TARGET%\lib\rustlib\src\rust\src
+  - rustc -Vv
+  - cargo -V
+
+# 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents
+# the "directory does not contain a project or solution file" error.
+# source: https://github.com/starkat99/appveyor-rust/blob/master/appveyor.yml#L113
+build: false
+
+# Equivalent to Travis' `script` phase
+# TODO modify this phase as you see fit
+test_script:
+  - cargo build --verbose
+  - cargo test
+
+cache:
+  - target
+  - C:\Users\appveyor\.cargo\registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
 - Provide suggestions for global paths in more cases #765
+- Return fewer duplicate suggestions #778
 
 ## 2.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
 - Provide suggestions for global paths in more cases #765
 - Return fewer duplicate suggestions #778
+- Handle cases where mod names and trait methods collide, such as `fmt` #774
 
 ## 2.0.9
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_errors 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -21,14 +20,6 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -140,14 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "nom"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,25 +161,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "regex-syntax"
-version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -282,29 +248,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -349,31 +297,13 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "vec_map"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "void"
-version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -388,7 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
@@ -403,14 +332,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d5b7638a1f03815d94e88cb3b3c08e87f0db4d683ef499d1836aaf70a45623f"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
@@ -420,9 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-"checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5934776c3ac1bea4a9d56620d6bf2d483b20d394e49581db40f187e1118ff667"
@@ -430,10 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
-"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ doc = false
 debug = true
 
 [dependencies]
-lazy_static = "0.2"
 log = "0.3.6"
 syntex_syntax = "0.52.0"
 syntex_errors = "0.52.0"
@@ -29,7 +28,6 @@ toml = "0.2.1"
 env_logger = "0.3.4"
 typed-arena = "1.2"
 clap = "2.19"
-regex = "0.2"
 
 [dependencies.clippy]
 version = "0.0.103"
@@ -37,6 +35,7 @@ optional = true
 
 [dev-dependencies]
 rand = "0.3"
+lazy_static = "0.2"
 
 [features]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # *Racer* - code completion for [Rust](http://www.rust-lang.org/)
 
 [![Build Status](https://travis-ci.org/racer-rust/racer.svg?branch=master)](https://travis-ci.org/racer-rust/racer)
+[![Build status](https://ci.appveyor.com/api/projects/status/hq51xvr5wpfcfqgt/branch/master?svg=true)](https://ci.appveyor.com/project/TedDriggs/racer-xr5g5/branch/master)
+
 
 ![racer completion screenshot](images/racer_completion.png)
 

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(feature = "clippy", allow(clippy))]
 #![cfg_attr(all(feature = "clippy", not(test)), deny(print_stdout))]
 
-#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 
 extern crate syntex_syntax;
@@ -12,7 +11,6 @@ extern crate syntex_errors;
 extern crate toml;
 extern crate env_logger;
 extern crate typed_arena;
-extern crate regex;
 
 #[macro_use]
 mod testutils;

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -315,14 +315,13 @@ pub fn match_mod(msrc: Src, blobstart: Point, blobend: Point,
                  local: bool, session: &Session) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
     if let Some(start) = find_keyword(blob, "mod", searchstr, search_type, local) {
-        debug!("found a module: |{}|", blob);
         let l = match search_type {
             ExactMatch => searchstr, // already checked in find_keyword
             StartsWith => &blob[start..find_ident_end(blob, start+searchstr.len())]
         };
 
         if blob.find('{').is_some() {
-            debug!("found an inline module!");
+            debug!("found a module inline: |{}|", blob);
 
             return Some(Match {
                 matchstr: l.to_owned(),
@@ -337,6 +336,8 @@ pub fn match_mod(msrc: Src, blobstart: Point, blobend: Point,
                 docs: String::new(),
             })
         } else {
+            debug!("found a module declaration: |{}|", blob);
+
             // get module from path attribute
             if let Some(modpath) = scopes::get_module_file_from_path(msrc, blobstart,filepath.parent().unwrap()) {
                 let msrc = session.load_file(&modpath);

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -23,7 +23,7 @@ pub type PendingImports<'stack, 'fp> = StackLinkedListNode<'stack, PendingImport
 pub type MIter = option::IntoIter<Match>;
 pub type MChain<T> = iter::Chain<T, MIter>;
 
-// Should I return a boxed trait object to make this signature nicer?
+// TODO change return type to `impl Iterator<Item = Match>`
 pub fn match_types(src: Src, blobstart: Point, blobend: Point,
                    searchstr: &str, filepath: &Path,
                    search_type: SearchType,

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -5,8 +5,12 @@ use core::SearchType::{self, ExactMatch, StartsWith};
 use core::{Match, Src, Session, Coordinate, SessionExt, Ty, Point};
 use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField, Impl, TraitImpl, MatchArm, Builtin};
 use core::Namespace;
+<<<<<<< HEAD
 
 use util::{self, closure_valid_arg_scope, symbol_matches, txt_matches, find_ident_end};
+=======
+use util::{self, symbol_matches, txt_matches, find_ident_end};
+>>>>>>> Search fn args for pub(restricted) fns
 use matchers::find_doc;
 use cargo;
 use std::path::{Path, PathBuf};

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -511,6 +511,13 @@ fn search_scope_headers(point: Point, scopestart: Point, msrc: Src, searchstr: &
                             out.push(m);
                         }
                     });
+
+                    trace!(
+                        "Found {} methods matching `{}` for trait `{}`", 
+                        out.len(), 
+                        searchstr, 
+                        m.matchstr);
+
                     return out.into_iter();
                 }
 

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -5,12 +5,8 @@ use core::SearchType::{self, ExactMatch, StartsWith};
 use core::{Match, Src, Session, Coordinate, SessionExt, Ty, Point};
 use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField, Impl, TraitImpl, MatchArm, Builtin};
 use core::Namespace;
-<<<<<<< HEAD
 
 use util::{self, closure_valid_arg_scope, symbol_matches, txt_matches, find_ident_end};
-=======
-use util::{self, symbol_matches, txt_matches, find_ident_end};
->>>>>>> Search fn args for pub(restricted) fns
 use matchers::find_doc;
 use cargo;
 use std::path::{Path, PathBuf};

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -6,8 +6,7 @@ use core::{self, Coordinate};
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::str::from_utf8;
-use util::char_at;
-use regex::Regex;
+use util::{closure_valid_arg_scope, char_at};
 
 fn find_close<'a, A>(iter: A, open: u8, close: u8, level_end: u32) -> Option<Point> where A: Iterator<Item=&'a u8> {
     let mut levels = 0u32;
@@ -33,12 +32,7 @@ pub fn find_closure_scope_start(src: Src, point: Point, parentheses_open_pos: Po
 
     let src_between_parent = mask_comments(src.from_to(parentheses_open_pos, closing_paren_pos));
 
-    if Regex::new(r"\|[^\|]+\|").unwrap().find(src_between_parent.as_str()).is_some() {
-        Some(parentheses_open_pos)
-    } else {
-        None
-    }
-}
+    closure_valid_arg_scope(&src_between_parent).map(|_ |parentheses_open_pos)}
 
 pub fn scope_start(src: Src, point: Point) -> Point {
     let masked_src = mask_comments(src.to(point));

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -68,7 +68,7 @@ pub fn first_param_is_self(blob: &str) -> bool {
             while let Some(start) = blob[skip_generic..].find('(') {
                 let end = scopes::find_closing_paren(blob, start + 1);
                 let is_self = txt_matches(ExactMatch, "self", &blob[(start + 1)..end]);
-                debug!("searching fn args: |{}| {}",
+                trace!("searching fn args for self: |{}| {}",
                        &blob[(start + 1)..end],
                        is_self);
                 return is_self;

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -31,30 +31,10 @@ pub fn first_param_is_self(blob: &str) -> bool {
     /// Restricted visibility introduces the possibility of `pub(in ...)` at the start
     /// of a method declaration. To counteract this, we restrict the search to only
     /// look at text _after_ the visibility declaration.
-    let skip_restricted = if blob.trim_left().starts_with("pub") {
-        let mut level = 0;
-        let mut skip_restricted = 0;
-        for (i, c) in blob[3..].char_indices() {
-            match c {
-                '(' => level += 1,
-                ')' => level -= 1,
-                _ if level >= 1 => (),
-                _ if util::is_ident_char(c) => {
-                    skip_restricted = i + 3;
-                    break;
-                },
-                _ => continue,
-            }
-        }
-
-        skip_restricted
-    } else {
-        0
-    };
-
+    ///
     /// Having found the end of the visibility declaration, we now start the search
     /// for method parameters.
-    let blob = &blob[skip_restricted..];
+    let blob = util::trim_visibility(blob);
 
     // skip generic arg
     // consider 'pub fn map<U, F: FnOnce(T) -> U>(self, f: F)'

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -479,3 +479,36 @@ fn test_trim_visibility() {
     assert_eq!(trim_visibility("pub(crate)   struct"), "struct");
     assert_eq!(trim_visibility("pub (in super)  const fn"), "const fn");
 }
+
+/// Checks if the completion point is in a function declaration by looking
+/// to see if the second-to-last word is `fn`.
+pub fn in_fn_name(line_before_point: &str) -> bool {
+    /// Determine if the cursor is sitting in the whitespace after typing `fn ` before
+    /// typing a name.
+    let has_started_name = !line_before_point.ends_with(|c: char| c.is_whitespace());
+
+    let mut words = line_before_point.split_whitespace().rev();
+
+    // Make sure we haven't finished the name and started generics or arguments
+    if has_started_name {
+        if let Some(ident) = words.next() {
+            if ident.chars().any(|c| !is_ident_char(c)) {
+                return false;
+            }
+        }
+    }
+    
+    words
+        .next()
+        .map(|word| word == "fn")
+        .unwrap_or_default()
+}
+
+#[test]
+fn test_in_fn_name() {
+    assert!(in_fn_name("fn foo"));
+    assert!(in_fn_name(" fn  foo"));
+    assert!(in_fn_name("fn "));
+    assert!(!in_fn_name("fn foo(b"));
+    assert!(!in_fn_name("fn"));
+}

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -478,7 +478,6 @@ fn test_trim_visibility() {
     assert_eq!(trim_visibility("pub fn"), "fn");
     assert_eq!(trim_visibility("pub(crate)   struct"), "struct");
     assert_eq!(trim_visibility("pub (in super)  const fn"), "const fn");
-<<<<<<< HEAD
 }
 
 /// Checks if the completion point is in a function declaration by looking
@@ -512,6 +511,4 @@ fn test_in_fn_name() {
     assert!(in_fn_name("fn "));
     assert!(!in_fn_name("fn foo(b"));
     assert!(!in_fn_name("fn"));
-=======
->>>>>>> Search fn args for pub(restricted) fns
 }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -478,6 +478,7 @@ fn test_trim_visibility() {
     assert_eq!(trim_visibility("pub fn"), "fn");
     assert_eq!(trim_visibility("pub(crate)   struct"), "struct");
     assert_eq!(trim_visibility("pub (in super)  const fn"), "const fn");
+<<<<<<< HEAD
 }
 
 /// Checks if the completion point is in a function declaration by looking
@@ -511,4 +512,6 @@ fn test_in_fn_name() {
     assert!(in_fn_name("fn "));
     assert!(!in_fn_name("fn foo(b"));
     assert!(!in_fn_name("fn"));
+=======
+>>>>>>> Search fn args for pub(restricted) fns
 }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -445,3 +445,37 @@ impl<'stack, T> StackLinkedListNode<'stack, T>
         false
     }
 }
+
+/// Removes `pub(...)` from the start of a blob so that other code
+/// can assess the struct/trait/fn without worrying about restricted
+/// visibility.
+pub fn trim_visibility(blob: &str) -> &str {
+    if !blob.trim_left().starts_with("pub") {
+        return blob
+    }
+    
+    let mut level = 0;
+    let mut skip_restricted = 0;
+    for (i, c) in blob[3..].char_indices() {
+        match c {
+            '(' => level += 1,
+            ')' => level -= 1,
+            _ if level >= 1 => (),
+            // stop on the first thing that isn't whitespace
+            _ if is_ident_char(c) => {
+                skip_restricted = i + 3;
+                break;
+            },
+            _ => continue,
+        }
+    }
+
+    &blob[skip_restricted..]
+}
+
+#[test]
+fn test_trim_visibility() {
+    assert_eq!(trim_visibility("pub fn"), "fn");
+    assert_eq!(trim_visibility("pub(crate)   struct"), "struct");
+    assert_eq!(trim_visibility("pub (in super)  const fn"), "const fn");
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3599,6 +3599,48 @@ fn mod_restricted_fn_completes() {
 }
 
 #[test]
+fn finds_definition_of_fn_arg() {
+    let _lock = sync!();
+    let src = r#"
+    pub fn say_hello(name: String) {
+        println!("{}", nam~e);
+    }
+    "#;
+
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "name");
+}
+
+#[test]
+fn finds_definition_of_crate_restricted_fn_arg() {
+    let _lock = sync!();
+    let src = r#"
+    pub(crate) fn say_hello(name: String) {
+        println!("{}", nam~e);
+    }
+    "#;
+
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "name");
+}
+
+/// This test should work, but may be failing because there is no `mod foo`
+/// in the generated code we parse to get the signature.
+#[test]
+#[ignore]
+fn finds_definition_of_mod_restricted_fn_arg() {
+    let _lock = sync!();
+    let src = r#"
+    pub(in foo) fn say_hello(name: String) {
+        println!("{}", nam~e);
+    }
+    "#;
+
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "name");
+}
+
+#[test]
 fn finds_definition_of_super_restricted_fn() {
     let _lock = sync!();
     let src = r#"

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3458,6 +3458,82 @@ fn closure_bracket_scope_nested_match_outside() {
     assert_eq!("| x: i32 |", got.contextstr);
 }
 
+// Issue: https://github.com/racer-rust/racer/issues/754
+#[test]
+fn closure_dont_detect_normal_pipes() {
+    let _lock = sync!();
+
+    let src = "
+    enum Fruit {
+        Apple = 1,
+    }
+
+    fn foo(ty: Fruit) -> bool {
+        (1 as u8 | Fruit~::Apple as u8) == Fruit::Apple as u8
+    }
+
+    fn bar(ty: Fruit) -> bool {
+        match ty {
+            Fruit::Apple |
+            Fruit::Apple => {
+                false
+            }
+        }
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("Fruit", got.matchstr);
+    assert_eq!(got.mtype, MatchType::Enum);
+}
+
+#[test]
+fn closure_test_curly_brackets_in_args() {
+    let _lock = sync!();
+    
+    let src ="
+    struct Foo {
+        bar: u16
+    }
+
+    fn example() -> Result<Foo, ()> {
+        Ok(Foo { bar: 10 })
+    }
+
+    fn main() {
+        example().and_then(|Foo { bar }| { println!(\"{}\", bar~); Ok(()) });
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("bar", got.matchstr);
+    assert_eq!("|Foo { bar }|", got.contextstr);
+}
+
+#[test]
+fn closure_test_multiple_curly_brackets_in_args() {
+    let _lock = sync!();
+    
+    let src ="
+    struct Foo {
+        bar: u16
+    }
+
+    fn example() -> Result<Foo, ()> {
+        Ok(Foo { bar: 10 })
+    }
+
+    fn main() {
+        example().and_then(|Foo { bar }, Foo { ex }, Foo { b }| { println!(\"{}\", bar~); Ok(()) });
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("bar", got.matchstr);
+    assert_eq!("|Foo { bar }, Foo { ex }, Foo { b }|", got.contextstr);
+}
+
+
 #[test]
 fn literal_string_method() {
     let _lock = sync!();

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2947,6 +2947,34 @@ fn completes_optional_trait_fn_in_trait_impl() {
     assert_eq!(got.contextstr, "fn traitf() -> bool");
 }
 
+#[test]
+fn completes_optional_trait_fn_in_trait_impl() {
+    let _lock = sync!();
+
+    let src = "
+    mod sub {
+        pub trait Trait {
+            fn traitf() -> bool {
+                true
+            }
+            
+            fn traitm(&self) -> bool;
+        }
+
+        pub struct Foo(bool);
+
+        impl Trait for Foo {
+            fn traitf~() -> bool { false }
+            fn traitm(&self) -> bool { true }
+        }
+    }
+    ";
+
+    let got = get_one_completion(src, None);
+    assert_eq!(got.matchstr, "traitf");
+    assert_eq!(got.contextstr, "fn traitf() -> bool");
+}
+
 /// Addresses https://github.com/racer-rust/racer/issues/680. In this case,
 /// `sub` should not be interpreted as a method name; it didn't appear after
 /// `fn` and therefore would need `Self::`, `self.` or another qualified name

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2907,6 +2907,34 @@ fn completes_trait_fn_in_trait_impl() {
     assert_eq!(got.contextstr, "fn traitf() -> bool");
 }
 
+#[test]
+fn completes_optional_trait_fn_in_trait_impl() {
+    let _lock = sync!();
+
+    let src = "
+    mod sub {
+        pub trait Trait {
+            fn traitf() -> bool {
+                true
+            }
+            
+            fn traitm(&self) -> bool;
+        }
+
+        pub struct Foo(bool);
+
+        impl Trait for Foo {
+            fn traitf~() -> bool { false }
+            fn traitm(&self) -> bool { true }
+        }
+    }
+    ";
+
+    let got = get_one_completion(src, None);
+    assert_eq!(got.matchstr, "traitf");
+    assert_eq!(got.contextstr, "fn traitf() -> bool");
+}
+
 /// Addresses https://github.com/racer-rust/racer/issues/680. In this case,
 /// `sub` should not be interpreted as a method name; it didn't appear after
 /// `fn` and therefore would need `Self::`, `self.` or another qualified name

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2992,6 +2992,48 @@ fn finds_mod_with_same_name_as_trait_method_in_body() {
     assert_eq!(got.matchstr, "Formatter");
 }
 
+/// Also addresses #680
+#[test]
+fn finds_fmt_formatter() {
+    let _lock = sync!();
+    let src = r#"
+    use std::fmt;
+
+    struct Foo;
+
+    impl fmt::Display for Foo {
+        fn fmt(&self, f: &mut fmt::Formatt~er) -> fmt::Result {
+            write!(f, "Hello")
+        }
+    }
+    "#;
+
+    let got = get_all_completions(src, None);
+    assert!(!got.is_empty());
+    assert_eq!(got[0].matchstr, "Formatter");
+}
+
+/// Also addresses #680
+#[test]
+fn finds_fmt_method() {
+    let _lock = sync!();
+    let src = r#"
+    use std::fmt;
+
+    struct Foo;
+
+    impl fmt::Display for Foo {
+        fn fm~t(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "Hello")
+        }
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "fmt");
+    assert_eq!(got.mtype, MatchType::Function);
+}
+
 #[test]
 fn finds_field_with_same_name_as_method() {
     let _lock = sync!();

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2871,24 +2871,39 @@ fn completes_trait_methods_in_trait_impl() {
 
         impl Trait for Foo {
             fn traitf() -> bool { false }
+            fn traitm~(&self) -> bool { true }
+        }
+    }
+    ";
+
+    let got = get_one_completion(src, None);
+    assert_eq!(got.matchstr, "traitm");
+    assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
+}
+
+#[test]
+fn completes_trait_fn_in_trait_impl() {
+    let _lock = sync!();
+
+    let src = "
+    mod sub {
+        pub trait Trait {
+            fn traitf() -> bool;
+            fn traitm(&self) -> bool;
+        }
+
+        pub struct Foo(bool);
+
+        impl Trait for Foo {
+            fn trait~f() -> bool { false }
             fn traitm(&self) -> bool { true }
         }
     }
     ";
 
-    let f = TmpFile::new(src);
-    let path = f.path();
-    let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
-    let cursor = Coordinate { line: 11, column: 21 };
-    let got = complete_from_file(&path, cursor, &session).nth(0).unwrap();
+    let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "traitf");
     assert_eq!(got.contextstr, "fn traitf() -> bool");
-
-    let cursor = Coordinate { line: 12, column: 21 };
-    let got = complete_from_file(&path, cursor, &session).nth(0).unwrap();
-    assert_eq!(got.matchstr, "traitm");
-    assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
 }
 
 /// Addresses https://github.com/racer-rust/racer/issues/680. In this case,

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2883,6 +2883,63 @@ fn completes_trait_methods_in_trait_impl() {
     assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
 }
 
+/// Addresses https://github.com/racer-rust/racer/issues/680. In this case,
+/// `sub` should not be interpreted as a method name; it didn't appear after
+/// `fn` and therefore would need `Self::`, `self.` or another qualified name
+/// to be syntactically valid.
+#[test]
+fn finds_mod_with_same_name_as_trait_method_in_sig() {
+    let _lock = sync!();
+
+    let src = "
+    mod sub {
+        pub struct Formatter;
+
+        pub trait Fmt {
+            fn sub(&self, f: &Formatter);
+        }
+    }
+
+    struct Sample;
+
+    impl sub::Fmt for Sample {
+        fn sub(&self, f: &sub::Fo~rmatter) {
+
+        }
+    }
+    ";
+
+    let got = get_one_completion(src, None);
+    assert_eq!(got.matchstr, "Formatter");
+}
+
+/// Also addresses issue #680.
+#[test]
+fn finds_mod_with_same_name_as_trait_method_in_body() {
+    let _lock = sync!();
+
+    let src = "
+    mod sub {
+        pub struct Formatter;
+
+        pub trait Fmt {
+            fn sub(&self) -> sub::Formatter;
+        }
+    }
+
+    struct Sample;
+
+    impl sub::Fmt for Sample {
+        fn sub(&self) -> sub::Formatter {
+            sub::Fo~rmatter
+        }
+    }
+    ";
+
+    let got = get_one_completion(src, None);
+    assert_eq!(got.matchstr, "Formatter");
+}
+
 #[test]
 fn finds_field_with_same_name_as_method() {
     let _lock = sync!();

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2881,14 +2881,7 @@ fn completes_trait_methods_in_trait_impl() {
     assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 /// Check if user is offered a completion for a static function defined by a trait.
-=======
->>>>>>> Fix broken test
-=======
-/// Check if user is offered a completion for a static function defined by a trait.
->>>>>>> Fix #680
 #[test]
 fn completes_trait_fn_in_trait_impl() {
     let _lock = sync!();
@@ -2903,39 +2896,6 @@ fn completes_trait_fn_in_trait_impl() {
         pub struct Foo(bool);
 
         impl Trait for Foo {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            fn traitf~() -> bool { false }
-=======
-            fn trait~f() -> bool { false }
->>>>>>> Fix broken test
-            fn traitm(&self) -> bool { true }
-        }
-    }
-    ";
-
-    let got = get_one_completion(src, None);
-    assert_eq!(got.matchstr, "traitf");
-    assert_eq!(got.contextstr, "fn traitf() -> bool");
-}
-
-#[test]
-fn completes_optional_trait_fn_in_trait_impl() {
-    let _lock = sync!();
-
-    let src = "
-    mod sub {
-        pub trait Trait {
-            fn traitf() -> bool {
-                true
-            }
-            
-            fn traitm(&self) -> bool;
-        }
-
-        pub struct Foo(bool);
-
-        impl Trait for Foo {
             fn traitf~() -> bool { false }
             fn traitm(&self) -> bool { true }
         }
@@ -2973,63 +2933,6 @@ fn completes_optional_trait_fn_in_trait_impl() {
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "traitf");
     assert_eq!(got.contextstr, "fn traitf() -> bool");
-}
-
-/// Addresses https://github.com/racer-rust/racer/issues/680. In this case,
-/// `sub` should not be interpreted as a method name; it didn't appear after
-/// `fn` and therefore would need `Self::`, `self.` or another qualified name
-/// to be syntactically valid.
-#[test]
-fn finds_mod_with_same_name_as_trait_method_in_sig() {
-    let _lock = sync!();
-
-    let src = "
-    mod sub {
-        pub struct Formatter;
-
-        pub trait Fmt {
-            fn sub(&self, f: &Formatter);
-        }
-    }
-
-    struct Sample;
-
-    impl sub::Fmt for Sample {
-        fn sub(&self, f: &sub::Fo~rmatter) {
-
-        }
-    }
-    ";
-
-    let got = get_one_completion(src, None);
-    assert_eq!(got.matchstr, "Formatter");
-}
-
-/// Also addresses issue #680.
-#[test]
-fn finds_mod_with_same_name_as_trait_method_in_body() {
-    let _lock = sync!();
-
-    let src = "
-    mod sub {
-        pub struct Formatter;
-
-        pub trait Fmt {
-            fn sub(&self) -> sub::Formatter;
-        }
-    }
-
-    struct Sample;
-
-    impl sub::Fmt for Sample {
-        fn sub(&self) -> sub::Formatter {
-            sub::Fo~rmatter
-        }
-    }
-    ";
-
-    let got = get_one_completion(src, None);
-    assert_eq!(got.matchstr, "Formatter");
 }
 
 /// Addresses https://github.com/racer-rust/racer/issues/680. In this case,

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2882,9 +2882,13 @@ fn completes_trait_methods_in_trait_impl() {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 /// Check if user is offered a completion for a static function defined by a trait.
 =======
 >>>>>>> Fix broken test
+=======
+/// Check if user is offered a completion for a static function defined by a trait.
+>>>>>>> Fix #680
 #[test]
 fn completes_trait_fn_in_trait_impl() {
     let _lock = sync!();
@@ -2900,6 +2904,7 @@ fn completes_trait_fn_in_trait_impl() {
 
         impl Trait for Foo {
 <<<<<<< HEAD
+<<<<<<< HEAD
             fn traitf~() -> bool { false }
 =======
             fn trait~f() -> bool { false }
@@ -2912,7 +2917,6 @@ fn completes_trait_fn_in_trait_impl() {
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "traitf");
     assert_eq!(got.contextstr, "fn traitf() -> bool");
-<<<<<<< HEAD
 }
 
 #[test]
@@ -2998,8 +3002,6 @@ fn finds_mod_with_same_name_as_trait_method_in_body() {
 
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "Formatter");
-=======
->>>>>>> Fix broken test
 }
 
 /// Addresses https://github.com/racer-rust/racer/issues/680. In this case,

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2881,7 +2881,10 @@ fn completes_trait_methods_in_trait_impl() {
     assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
 }
 
+<<<<<<< HEAD
 /// Check if user is offered a completion for a static function defined by a trait.
+=======
+>>>>>>> Fix broken test
 #[test]
 fn completes_trait_fn_in_trait_impl() {
     let _lock = sync!();
@@ -2896,7 +2899,11 @@ fn completes_trait_fn_in_trait_impl() {
         pub struct Foo(bool);
 
         impl Trait for Foo {
+<<<<<<< HEAD
             fn traitf~() -> bool { false }
+=======
+            fn trait~f() -> bool { false }
+>>>>>>> Fix broken test
             fn traitm(&self) -> bool { true }
         }
     }
@@ -2905,6 +2912,7 @@ fn completes_trait_fn_in_trait_impl() {
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "traitf");
     assert_eq!(got.contextstr, "fn traitf() -> bool");
+<<<<<<< HEAD
 }
 
 #[test]
@@ -2990,6 +2998,8 @@ fn finds_mod_with_same_name_as_trait_method_in_body() {
 
     let got = get_one_completion(src, None);
     assert_eq!(got.matchstr, "Formatter");
+=======
+>>>>>>> Fix broken test
 }
 
 /// Addresses https://github.com/racer-rust/racer/issues/680. In this case,

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2881,6 +2881,7 @@ fn completes_trait_methods_in_trait_impl() {
     assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
 }
 
+/// Check if user is offered a completion for a static function defined by a trait.
 #[test]
 fn completes_trait_fn_in_trait_impl() {
     let _lock = sync!();
@@ -2895,7 +2896,7 @@ fn completes_trait_fn_in_trait_impl() {
         pub struct Foo(bool);
 
         impl Trait for Foo {
-            fn trait~f() -> bool { false }
+            fn traitf~() -> bool { false }
             fn traitm(&self) -> bool { true }
         }
     }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1339,14 +1339,16 @@ fn keeps_newlines_in_external_mod_doc() {
     assert_eq!("The mods multiline documentation\n\nwith an empty line", got.docs);
 }
 
+/// Addresses https://github.com/racer-rust/racer/issues/618
 #[test]
-fn issue_618() {
+fn always_get_all_doc_lines() {
     let _lock = sync!();
 
     let src = "
 /// Orange
 /// juice
-pub fn appl~e() {
+pub fn apple() {
+    app~le()
 }";
 
     let got = get_only_completion(src, None);
@@ -1354,14 +1356,20 @@ pub fn appl~e() {
     assert_eq!("Orange\njuice", got.docs);
 }
 
+/// Addresses https://github.com/racer-rust/racer/issues/594
 #[test]
-fn issue_594() {
+fn find_complete_docs_with_parentheses_on_last_line() {
     let _lock = sync!();
 
     let src = "
 /// Hello world
 /// (quux)
-pub fn fo~o() {}";
+pub fn foo() {}
+
+pub fn bar() {
+    fo~o()
+}
+";
 
     let got = get_only_completion(src, None);
     assert_eq!("foo", got.matchstr);


### PR DESCRIPTION
Fix #680: Only show trait method suggestions when contextually relevant by checking if the cursor is in a function identifier, and otherwise not looking for trait method declarations and trait methods when searching for unprefixed values.

This is most useful when dealing with `std::fmt`; the example code for this module typically imports it at the mod level, which causes autocomplete not to work for writing the rest of the signature, where `fmt::Formatter` and `fmt::Result` will appear.