### PR TITLE
Add `point` and `coord` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
 - Provide suggestions for global paths in more cases #765
+- Add new commands for converting between points and coordinates in files #776
 
 ## 2.0.9
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -122,6 +122,7 @@ impl From<Coordinate> for Location {
 /// Internal cursor methods
 pub trait LocationExt {
     fn to_point(&self, src: &IndexedSource) -> Option<Point>;
+    fn to_coords(&self, src: &IndexedSource) -> Option<Coordinate>;
 }
 
 impl LocationExt for Location {
@@ -131,6 +132,13 @@ impl LocationExt for Location {
             Location::Coords(ref coords) => {
                 src.coords_to_point(coords)
             }
+        }
+    }
+
+    fn to_coords(&self, src: &IndexedSource) -> Option<Coordinate> {
+        match *self {
+            Location::Coords(val) => Some(val),
+            Location::Point(point) => src.point_to_coords(point)
         }
     }
 }
@@ -785,6 +793,28 @@ impl<'c> SessionExt for Session<'c> {
         self.cache.load_file_and_mask_comments(filepath)
     }
 }
+
+/// Get the racer point of a line/character number pair for a file.
+pub fn to_point<'c, P>(
+    coords: Coordinate, 
+    path: P, 
+    session: &'c Session
+) -> Option<Point> 
+    where 
+        P: AsRef<path::Path> {
+    Location::from(coords).to_point(&session.load_file(path.as_ref()))
+}
+
+/// Get the racer point of a line/character number pair for a file.
+pub fn to_coords<'c, P>(
+    point: Point, 
+    path: P, 
+    session: &'c Session
+) -> Option<Coordinate> 
+    where 
+        P: AsRef<path::Path> {
+    Location::from(point).to_coords(&session.load_file(path.as_ref()))
+} 
 
 /// Find completions for a fully qualified name like `std::io::`
 ///

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -29,7 +29,7 @@ mod matchers;
 mod snippets;
 mod cargo;
 
-pub use core::{find_definition, complete_from_file, complete_fully_qualified_name};
+pub use core::{find_definition, complete_from_file, complete_fully_qualified_name, to_point, to_coords};
 pub use snippets::snippet_for_match;
 pub use core::{Match, MatchType, PathSearch};
 pub use core::{FileCache, Session, Coordinate, Location, FileLoader, Point, SourceByteRange};


### PR DESCRIPTION
This fixes #770 by adding two new commands to the CLI interface:

* The `point` command converts coordinates to points
* The `coord` command converts points to coordinates

These are exposed as new message types. Conversion failure is silent to avoid causing problems for the daemon; users can observe the failure by noting the lack of a conversion message in the output.