### PR TITLE
Dedup matches in complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
 - Provide suggestions for global paths in more cases #765
+- Return fewer duplicate suggestions #777
 
 ## 2.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support resolving `use as` aliases declared in multi-element `use` statements #753
 - Provide suggestions for global paths in more cases #765
-- Return fewer duplicate suggestions #777
+- Return fewer duplicate suggestions #778
 
 ## 2.0.9
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -97,6 +97,15 @@ pub struct Match {
     pub docs: String,
 }
 
+impl Match {
+    /// Checks if two matches can be considered the same for deduplication purposes.
+    fn is_same_as(&self, other: &Match) -> bool {
+        self.point == other.point 
+        && self.matchstr == other.matchstr
+        && self.filepath == other.filepath
+    }
+}
+
 /// The cursor position used by public search methods
 #[derive(Debug, Clone, Copy)]
 pub enum Location {
@@ -819,9 +828,11 @@ pub fn complete_fully_qualified_name<'c, S, P>(
     where S: AsRef<str>,
           P: AsRef<path::Path>,
 {
-    let matches = complete_fully_qualified_name_(query.as_ref(), path.as_ref(), session);
+    let mut matches = complete_fully_qualified_name_(query.as_ref(), path.as_ref(), session);
+    matches.dedup_by(|a, b| a.is_same_as(b));
+    
     MatchIter {
-        matches: matches,
+        matches: matches.into_iter(),
         session: session
     }
 }
@@ -831,7 +842,7 @@ fn complete_fully_qualified_name_(
     query: &str,
     path: &path::Path,
     session: &Session
-) -> vec::IntoIter<Match> {
+) -> Vec<Match> {
     let p: Vec<&str> = query.split("::").collect();
 
     let mut matches = Vec::new();
@@ -855,7 +866,7 @@ fn complete_fully_qualified_name_(
         }
     }
 
-    matches.into_iter()
+    matches
 }
 
 
@@ -902,10 +913,12 @@ pub fn complete_from_file<'c, P, C>(
     where P: AsRef<path::Path>,
           C: Into<Location>
 {
-    let matches = complete_from_file_(filepath.as_ref(), cursor.into(), session);
+    let mut matches = complete_from_file_(filepath.as_ref(), cursor.into(), session);
+    matches.dedup_by(|a, b| a.is_same_as(b));
+
     MatchIter {
+        matches: matches.into_iter(),
         session: session,
-        matches: matches,
     }
 }
 
@@ -913,7 +926,7 @@ fn complete_from_file_(
     filepath: &path::Path,
     cursor: Location,
     session: &Session
-) -> vec::IntoIter<Match> {
+) -> Vec<Match> {
     let src = session.load_file_and_mask_comments(filepath);
     let src_text = &src.as_src()[..];
 
@@ -922,7 +935,7 @@ fn complete_from_file_(
         Some(pos) => pos,
         None => {
             debug!("Failed to convert cursor to point");
-            return Vec::new().into_iter();
+            return Vec::new();
         }
     };
 
@@ -980,7 +993,8 @@ fn complete_from_file_(
             });
         }
     }
-    out.into_iter()
+    
+    out
 }
 
 fn complete_field_for_ty(ty: Ty, searchstr: &str, stype: SearchType, session: &Session, out: &mut Vec<Match>) {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -99,6 +99,10 @@ pub struct Match {
 
 impl Match {
     /// Checks if two matches can be considered the same for deduplication purposes.
+    ///
+    /// This could be the basis for a `PartialEq` implementation in the future,
+    /// but in the interest of minimizing the crate's public API surface it's exposed
+    /// as a private method for now.
     fn is_same_as(&self, other: &Match) -> bool {
         self.point == other.point 
         && self.matchstr == other.matchstr

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -315,14 +315,13 @@ pub fn match_mod(msrc: Src, blobstart: Point, blobend: Point,
                  local: bool, session: &Session) -> Option<Match> {
     let blob = &msrc[blobstart..blobend];
     if let Some(start) = find_keyword(blob, "mod", searchstr, search_type, local) {
-        debug!("found a module: |{}|", blob);
         let l = match search_type {
             ExactMatch => searchstr, // already checked in find_keyword
             StartsWith => &blob[start..find_ident_end(blob, start+searchstr.len())]
         };
 
         if blob.find('{').is_some() {
-            debug!("found an inline module!");
+            debug!("found a module inline: |{}|", blob);
 
             return Some(Match {
                 matchstr: l.to_owned(),
@@ -337,6 +336,8 @@ pub fn match_mod(msrc: Src, blobstart: Point, blobend: Point,
                 docs: String::new(),
             })
         } else {
+            debug!("found a module declaration: |{}|", blob);
+
             // get module from path attribute
             if let Some(modpath) = scopes::get_module_file_from_path(msrc, blobstart,filepath.parent().unwrap()) {
                 let msrc = session.load_file(&modpath);


### PR DESCRIPTION
Fix #645 by deduping adjacent matches in the `complete` functions. Matches are deduplicated by filepath, point in file, and matchstr. This tuple should be sufficient to uniquely identify a match.

There is still the possibility of duplicate matches if the duplicates are not adjacent in the returned results. That condition did not arise during testing.

This doesn't try to stop racer from finding items more than once; it instead just removes them before returning. This approach seemed to be the less invasive and lower-risk fix.