### PR TITLE
Remove usage of pub(crate) from two methods

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1159,7 +1159,7 @@ pub struct Search {
 }
 
 /// Attempt to resolve a name which occurs in a given file.
-pub(crate) fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: Point,
+pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: Point,
                     search_type: SearchType, namespace: Namespace,
                     session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     let mut out = Vec::new();
@@ -1401,7 +1401,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: Point,
     }
 }
 
-pub(crate) fn resolve_method(point: Point, msrc: Src, searchstr: &str,
+pub fn resolve_method(point: Point, msrc: Src, searchstr: &str,
                         filepath: &Path, search_type: SearchType, session: &Session,
                         pending_imports: &PendingImports) -> Vec<Match> {
 


### PR DESCRIPTION
Fixes #787

Using `cargo install` builds the code using the installer's local version of rust. For users who aren't yet on 1.18 or above, the presence of restricted visibility functions broke installation. Racer doesn't *need* to use restricted visibility on these, as all crate exports are done explicitly in lib.rs, so this fix should be harmless.