### PR TITLE
Added workspace support.

### DIFF
--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -705,8 +705,8 @@ pub fn get_crate_file(kratename: &str, from_path: &Path) -> Option<PathBuf> {
 
         let mut lockfile = tomlfile.clone();
         lockfile.pop();
-        if workspace.is_some() {
-            lockfile.push(workspace.unwrap());
+        if let Some(workspace) = workspace {
+            lockfile = workspace;
             trace!("get_crate_file workspace is {:?}", lockfile);
         }
         lockfile.push("Cargo.lock");

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -540,6 +540,8 @@ fn find_workspace_root<P>(path: P) -> Option<PathBuf>
         path.pop();
         Some(path)
     } else if path.pop() && path.pop() {
+        // If we haven't found the root and there is still more to search, discard the current
+        // Cargo.toml, move up a directory, and try again.
         find_workspace_root(path)
     } else {
         None


### PR DESCRIPTION
When searching for a lockfile, get_crate_file now searches upwards through the directory tree looking for a Cargo.toml file containing a `[workspace]` section. If it finds one, it then locates the corresponding Cargo.lock file.

This resolves #687 and is a replacement PR for #649.