### PR TITLE
Adds support for inferring the type of a match expression

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -527,9 +527,10 @@ impl<'c, 's> visit::Visitor for ExprTypeVisitor<'c, 's> {
             }
             ExprKind::Path(_, ref path) => {
                 debug!("expr is a path {:?}", to_racer_path(path));
+                let codemap::BytePos(lo) = path.span.lo;
                 self.result = resolve_ast_path(path,
                                  &self.scope.filepath,
-                                 self.scope.point,
+                                 self.scope.point + lo as usize,
                                  self.session).and_then(|m| {
                                      let msrc = self.session.load_file_and_mask_comments(&m.filepath);
                                      typeinf::get_type_of_match(m, msrc.as_src(), self.session)
@@ -695,10 +696,34 @@ impl<'c, 's> visit::Visitor for ExprTypeVisitor<'c, 's> {
                 };
             }
 
+            ExprKind::Match(_, ref arms) => {
+                debug!("match expr");
+
+                for arm in arms {
+                    self.visit_expr(&arm.body);
+
+                    // All match arms need to return the same result, so if we found a result
+                    // we can end the search.
+                    if self.result.is_some() {
+                        break;
+                    }
+                }
+            }
+
+            ExprKind::Block(ref block) => {
+                debug!("block expr");
+                visit::walk_block(self, &block);
+            }
+
             _ => {
                 debug!("- Could not match expr node type: {:?}",expr.node);
             }
-        }
+        };
+    }
+
+    fn visit_mac(&mut self, mac: &ast::Mac) {
+        // Just do nothing if we see a macro, but also prevent the panic! in the default impl.
+        debug!("ignoring visit_mac: {:?}", mac);
     }
 }
 
@@ -1117,7 +1142,8 @@ pub fn get_let_type(stmtstr: String, pos: Point, scope: Scope, session: &Session
         scope: scope,
         session: session,
         srctxt: stmtstr.clone(),
-        pos: pos, result: None
+        pos: pos,
+        result: None
     };
     if let Some(stmt) = string_to_stmt(stmtstr) {
         visit::walk_stmt(&mut v, &stmt);

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1112,8 +1112,8 @@ pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
 }
 
 pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: Point,
-                                   search_type: SearchType, namespace: Namespace,
-                                   session: &Session) -> vec::IntoIter<Match> {
+                             search_type: SearchType, namespace: Namespace,
+                             session: &Session) -> vec::IntoIter<Match> {
     debug!("resolve_path_with_str {:?}", path);
 
     let mut out = Vec::new();

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -153,7 +153,7 @@ fn get_type_of_let_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
         debug!("get_type_of_let_expr calling parse_let |{}|", blob);
 
         let pos = m.point - point - start;
-        let scope = Scope{ filepath: m.filepath.clone(), point: m.point };
+        let scope = Scope{ filepath: m.filepath.clone(), point: point };
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
@@ -172,7 +172,7 @@ fn get_type_of_let_block_expr(m: &Match, msrc: Src, session: &Session, prefix: &
         debug!("get_type_of_let_block_expr calling get_let_type |{}|", blob);
 
         let pos = m.point - stmtstart - point - start;
-        let scope = Scope{ filepath: m.filepath.clone(), point: m.point };
+        let scope = Scope{ filepath: m.filepath.clone(), point: stmtstart };
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
@@ -208,7 +208,7 @@ fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
         debug!("get_type_of_for_expr: |{}| {} {} {} {}", blob, m.point, stmtstart, forpos, start);
 
         let pos = m.point + 8 - stmtstart - forpos - start;
-        let scope = Scope{ filepath: m.filepath.clone(), point: m.point + 8 };
+        let scope = Scope{ filepath: m.filepath.clone(), point: stmtstart };
 
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3982,3 +3982,80 @@ fn completes_for_global_path_in_trait_impl_decl() {
     assert_eq!(got.matchstr, "Bar");
     assert_eq!(got.mtype, MatchType::Trait);
 }
+
+// Issue #755
+#[test]
+fn completes_for_match_type_inference_let_expr() {
+    let _lock = sync!();
+
+    let src = r#"
+    use std::fs::File;
+
+    fn main() {
+        let f = File::open("hey");
+
+        let f = match f {
+            Ok(file) => file,
+            Err(error) =>  {
+                panic!("Error opening file: {:?}", error)
+            }
+        };
+        f.set_p~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "set_permissions");
+    assert_eq!(got.mtype, MatchType::Function);
+}
+
+#[test]
+fn completes_for_match_type_inference_let_expr_with_block() {
+    let _lock = sync!();
+
+    let src = r#"
+    use std::fs::File;
+
+    fn main() {
+        let f = File::open("hey");
+
+        let f = match f {
+            Ok(file) => { file },
+            Err(error) =>  {
+                panic!("Error opening file: {:?}", error)
+            }
+        };
+        f.set_p~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "set_permissions");
+    assert_eq!(got.mtype, MatchType::Function);
+}
+
+#[test]
+fn completes_for_match_type_inference_let_expr_with_return() {
+    let _lock = sync!();
+
+    let src = r#"
+    use std::fs::File;
+
+    fn test() -> String {
+        let f = File::open("hey");
+
+        let f = match f {
+            Err(error) =>  {
+                return "result".to_string();
+            },
+            Ok(file) => { file }
+        };
+
+        f.set_p~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "set_permissions");
+    assert_eq!(got.mtype, MatchType::Function);
+}


### PR DESCRIPTION
This patch only supports simple match expressions. For more complex match
expressions, the ExprTypeVisitor needs to be extended.

Fixes: https://github.com/racer-rust/racer/issues/755