### PR TITLE
Fixing a bug that makes 2.0.11 unusable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,18 +1,3 @@
-[root]
-name = "racer"
-version = "2.0.10"
-dependencies = [
- "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_errors 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.5.3"
@@ -168,6 +153,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quine-mc_cluskey"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "racer"
+version = "2.0.11"
+dependencies = [
+ "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -84,7 +84,7 @@ pub struct Coordinate {
 }
 
 /// Context, source, and etc. for detected completion or definition
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Match {
     pub matchstr: String,
     pub filepath: path::PathBuf,
@@ -249,7 +249,7 @@ impl fmt::Display for Ty {
 }
 
 // The racer implementation of an ast::Path. Difference is that it is Send-able
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Path {
     pub global: bool,
     pub segments: Vec<PathSegment>
@@ -336,7 +336,7 @@ impl fmt::Display for Path {
     }
 }
 
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PathSegment {
     pub name: String,
     pub types: Vec<Path>
@@ -352,7 +352,7 @@ impl From<String> for PathSegment {
 }
 
 /// Information about generic types in a match
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct PathSearch {
     pub path: Path,
     pub filepath: path::PathBuf,

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -577,18 +577,31 @@ fn search_fn_args(fnstart: Point, open_brace_pos: Point, msrc: &str,
     out.into_iter()
 }
 
+#[test]
+fn test_do_file_search() {
+    let cache = core::FileCache::default();
+    let session = Session::new(&cache);
+    let mut matches = do_file_search("std", &Path::new("."), &session);
+
+    assert!(matches.len() > 1);
+
+    let first_match = matches.next().unwrap();
+
+    assert!(first_match.filepath.ends_with("src/libstd/lib.rs"));
+}
+
 pub fn do_file_search(
     searchstr: &str,
     currentdir: &Path,
     session: &Session
 ) -> vec::IntoIter<Match> {
-    debug!("do_file_search {}", searchstr);
+    debug!("do_file_search with search string \"{}\"", searchstr);
     let mut out = Vec::new();
 
-    let srcpaths = RUST_SRC_PATH.iter().map(|p| p.as_ref());
-    debug!("do_file_search srcpaths {:?}", srcpaths);
-    let v = srcpaths.chain(iter::once(currentdir));
-    debug!("do_file_search v is {:?}", v);
+    let srcpath = RUST_SRC_PATH.as_ref();
+    debug!("do_file_search srcpath: {:?}", srcpath);
+    let v = &[srcpath, currentdir][..];
+    debug!("do_file_search v: {:?}", v);
     for srcpath in v {
         if let Ok(iter) = std::fs::read_dir(srcpath) {
             for fpath_buf in iter.filter_map(|res| res.ok().map(|entry| entry.path())) {

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -365,6 +365,8 @@ fn check_rust_sysroot() -> Option<path::PathBuf> {
 pub fn get_rust_src_path() -> ::std::result::Result<path::PathBuf, RustSrcPathError> {
     use std::env;
 
+    debug!("Getting rust source path. Trying env var RUST_SRC_PATH.");
+
     if let Ok(ref srcpaths) = env::var("RUST_SRC_PATH") {
          if !srcpaths.is_empty() {
             for path in srcpaths.split(PATH_SEP) {
@@ -373,9 +375,13 @@ pub fn get_rust_src_path() -> ::std::result::Result<path::PathBuf, RustSrcPathEr
         }
     };
 
+    debug!("Nope. Trying rustc --sysroot and appending lib/rustlib/src/rust/src to that.");
+
     if let Some(path) = check_rust_sysroot() {
         return validate_rust_src_path(path);
     };
+
+    debug!("Nope. Trying default paths: /usr/local/src/rust/src and /usr/src/rust/src");
 
     let default_paths = [
         "/usr/local/src/rust/src",
@@ -387,6 +393,8 @@ pub fn get_rust_src_path() -> ::std::result::Result<path::PathBuf, RustSrcPathEr
             return Ok(path);
         }
     }
+
+    debug!("Nope. Rust source path not found!");
 
     return Err(RustSrcPathError::Missing)
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3350,7 +3350,7 @@ fn closure_scope_dont_match_bitwise_or() {
         // 1 || 2;
     }
     ";
-    
+
     let got = get_definition(src, None);
     println!("Unexpectedly found definition: {:?}", got);
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3349,7 +3349,8 @@ fn closure_scope_dont_match_bitwise_or() {
     fn baz() {
         // 1 || 2;
     }
-    ";   
+    ";
+    
     let got = get_definition(src, None);
     println!("Unexpectedly found definition: {:?}", got);
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3350,7 +3350,7 @@ fn closure_scope_dont_match_bitwise_or() {
         // 1 || 2;
     }
     ";
-
+    println!("THIS FAR");
     let got = get_definition(src, None);
     println!("Unexpectedly found definition: {:?}", got);
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3349,8 +3349,7 @@ fn closure_scope_dont_match_bitwise_or() {
     fn baz() {
         // 1 || 2;
     }
-    ";
-    
+    ";   
     let got = get_definition(src, None);
     println!("Unexpectedly found definition: {:?}", got);
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3350,7 +3350,7 @@ fn closure_scope_dont_match_bitwise_or() {
         // 1 || 2;
     }
     ";
-    println!("THIS FAR");
+    
     let got = get_definition(src, None);
     println!("Unexpectedly found definition: {:?}", got);
 }


### PR DESCRIPTION
There was a bug I didn't notice in my refactoring of the path search code. This PR fixes it, and adds a test case that should catch in the future if racer stops finding matches in some basic cases.

Sorry for the blunder. 2.0.11 should be yanked and 2.0.12 released with a fast schedule.

Also made cleaned up earlier tests in `nameres.rs` so that they won't block other tests from running if a single one fails.