### PR TITLE
Made RUST_SRC_PATH optional to support finding local files even when std source is missing.

### DIFF
--- a/fixtures/arst/src/submodule/mod.rs
+++ b/fixtures/arst/src/submodule/mod.rs
@@ -1,0 +1,3 @@
+pub fn hello_submodule() {
+	println!("Hello from submodule.");
+}

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -402,7 +402,7 @@ pub fn get_rust_src_path() -> Result<path::PathBuf, RustSrcPathError> {
         }
     }
 
-    debug!("Nope. Rust source path not found!");
+    warn!("Rust stdlib source path not found!");
 
     return Err(RustSrcPathError::Missing)
 }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -383,7 +383,7 @@ pub fn get_rust_src_path() -> Result<path::PathBuf, RustSrcPathError> {
         }
     };
 
-    debug!("Nope. Trying rustc --sysroot and appending lib/rustlib/src/rust/src to that.");
+    debug!("Nope. Trying rustc --print sysroot and appending lib/rustlib/src/rust/src to that.");
 
     if let Some(path) = check_rust_sysroot() {
         return validate_rust_src_path(path);


### PR DESCRIPTION
This fixes another regression from 2.0.10: Version 2.0.12 panics right away if it doesn't find the std source. This prevents searching for local files even in absence of the std source, which used to be possible.

It now stores the std source path as an optional value instead of panicking.

The regression made the RLS CI to break, because they didn't have the std source path installed there. They now have, but not panicking when std isn't found might still be a valuable thing, plus regressions aren't nice.

Also added a test case that searched for a local file. (Added a submodule to `fixtures/arst` for that.)