### PR TITLE
Solved Issue 816

### DIFF
--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -276,9 +276,10 @@ pub fn get_start_of_pattern(src: &str, point: Point) -> Point {
             },
             b')' => { levels += 1; },
             _ => {
-                if levels == 0 &&
-                    !util::is_pattern_char(char_at(src, i)) {
-                    return i+1;
+                let is_break_char = util::is_newline_byte(b)
+                    || !util::is_pattern_char(char_at(src, i));
+                if levels == 0 && is_break_char {
+                    return i + 1;
                 }
             }
         }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -15,6 +15,10 @@ pub fn is_pattern_char(c: char) -> bool {
     c.is_alphanumeric() || c.is_whitespace() || (c == '_') || (c == ':') || (c == '.')
 }
 
+pub fn is_newline_byte(b: u8) -> bool {
+    b == b'\n' || b == b'\r'
+}
+
 pub fn is_search_expr_char(c: char) -> bool {
     c.is_alphanumeric() || (c == '_') || (c == ':') || (c == '.')
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4106,3 +4106,23 @@ fn completes_for_match_type_inference_with_if() {
     assert_eq!(got.matchstr, "set_permissions");
     assert_eq!(got.mtype, MatchType::Function);
 }
+
+#[test]
+fn completes_for_let_below_multibyte_in_match() {
+    let _lock = sync!();
+    let src = "
+    fn main() {
+        let variable = 0;
+        let _ = match a {
+            1 => 1,
+            2 => 2,
+            // comment with a multibyte char, like ★
+            _ => {
+                let b = vari~;
+                3
+            }
+        };
+    }
+    ";
+    assert_eq!(get_all_completions(src, None)[0].matchstr, "variable");
+}


### PR DESCRIPTION
Solved #816.
Added check if the byte is newline byte, before calling ```util::is_pattern_char(char_at(src, i))```.
It's because multibyte char can occur over '\n' (in case of 1-liner comment).
And I found another problem around the  ```get_start_of_pattern```  so I will add new issue(#818).