### PR TITLE
modify test_do_file_search

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -585,9 +585,7 @@ fn test_do_file_search() {
 
     assert!(matches.len() > 1);
 
-    let first_match = matches.next().unwrap();
-
-    assert!(first_match.filepath.ends_with("src/libstd/lib.rs"));
+    assert!(matches.any(|ma| ma.filepath.ends_with("src/libstd/lib.rs")));
 }
 
 pub fn do_file_search(


### PR DESCRIPTION
We should use ```any``` because there's no guarantee of the order of files which ```do_file_search``` returns (In unix, stdlib's ```std::fs::read_dir``` using ```libc::opendir```, which has no guarantee of the order of files).