### PR TITLE
Add support for raw string with multi '#'s(Issue 815)

### DIFF
--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -3,8 +3,10 @@ use core::{Point, SourceByteRange};
 /// Type of the string
 #[derive(Clone, Copy, Debug)]
 enum StringType {
-    Raw(usize), // Raw(n) => raw string started with n #s
-    NotRaw,     // normal string
+    /// Raw(n) => raw string started with n #s
+    Raw(usize),
+    /// normal string starts with "
+    NotRaw,
 }
 
 #[derive(Clone,Copy)]
@@ -138,7 +140,6 @@ impl<'a> CodeIndicesIter<'a> {
             StringType::Raw(level) => {
                 // raw string (eg br#"\"#)
                 // detect corresponding end(if start is r##", ##") greedily
-                #[derive(Clone, Copy, Debug, Eq, PartialEq)]
                 enum SharpState {
                     Sharp((usize, usize)), // (Num of preceeding #s, Pos of end ")
                     None, // No preceeding "##...

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -140,11 +140,11 @@ impl<'a> CodeIndicesIter<'a> {
                 // detect corresponding end(if start is r##", ##") greedy
                 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
                 enum SharpState {
-                    Sharp((usize, usize)), // (Num of #, Pos of end ")
+                    Sharp((usize, usize)), // (Num of preceeding #s, Pos of end ")
                     None,
                 }
                 let mut cur_state = SharpState::None;
-                let mut end_was_find = false;
+                let mut end_was_found = false;
                 for (i, &b) in src_bytes[self.pos..].iter().enumerate() {
                     match cur_state {
                         SharpState::Sharp((n_sharp, pos_quote)) => {
@@ -162,13 +162,13 @@ impl<'a> CodeIndicesIter<'a> {
                     }
                     if let SharpState::Sharp((n_sharp, pos_quote)) = cur_state {
                         if n_sharp == level {
-                            end_was_find = true;
+                            end_was_found = true;
                             pos += pos_quote + 1;
                             break;
                         }
                     }
                 }
-                if !end_was_find {
+                if !end_was_found {
                     pos = src_bytes.len();
                 }
             }
@@ -209,6 +209,7 @@ impl<'a> CodeIndicesIter<'a> {
         if pos == 0 {
             return StringType::NotRaw;
         }
+        // now pos is at one byte after ", so we have to start at pos - 2
         for &b in src_bytes[..pos - 1].iter().rev() {
             match b {
                 b'#' => sharp += 1,

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4183,7 +4183,7 @@ fn completes_for_let_destracted_var_over_comment() {
 
 // For Issue #815
 #[test]
-fn complete_let_after_raw_string() {
+fn completes_methods_after_raw_string() {
     let _lock = sync!();
     let src = r##"
     fn main() {
@@ -4192,5 +4192,5 @@ fn complete_let_after_raw_string() {
         v.l~
     }
     "##;
-    assert_eq!(get_one_completion(src, None).matchstr, "len");
+    assert!(get_all_completions(src, None).iter().any(|ma| ma.matchstr == "len"));
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4180,3 +4180,17 @@ fn completes_for_let_destracted_var_over_comment() {
     ";
     assert_eq!(get_only_completion(src, None).matchstr, "variable");
 }
+
+// For Issue #815
+#[test]
+fn complete_let_after_raw_string() {
+    let _lock = sync!();
+    let src = r##"
+    fn main() {
+        let s = r#"""#;
+        let v = Vec::<u32>::new();
+        v.l~
+    }
+    "##;
+    assert_eq!(get_one_completion(src, None).matchstr, "len");
+}


### PR DESCRIPTION
Solves #815.
Add support for nested raw string like 
```rust
 r###" "" r#""# "###
```
to```CodeIndiceIter```.