### PR TITLE
 Fix panic on complete before first block statement 

### DIFF
--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -64,10 +64,10 @@ pub fn scope_start(src: Src, point: Point) -> Point {
 }
 
 pub fn find_stmt_start(msrc: Src, point: Point) -> Option<Point> {
-    // iterate the scope to find the start of the statement
+    // Iterate the scope to find the start of the statement that surrounds the point.
     let scopestart = scope_start(msrc, point);
     msrc.from(scopestart).iter_stmts()
-        .find(|&(_, end)| scopestart + end > point)
+        .find(|&(start, end)| scopestart + start < point && point < scopestart + end)
         .map(|(start, _)| scopestart + start)
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4106,3 +4106,34 @@ fn completes_for_match_type_inference_with_if() {
     assert_eq!(got.matchstr, "set_permissions");
     assert_eq!(got.mtype, MatchType::Function);
 }
+
+#[test]
+fn completes_before_first_statement() {
+    let _lock = sync!();
+
+    let src = r#"
+    fn test() {
+        ~
+        let x = 8;
+    }
+    "#;
+
+    let completions = get_all_completions(src, None);
+    assert!(completions.into_iter().any(|m| m.matchstr == "std"));
+}
+
+#[test]
+fn completes_between_statements() {
+    let _lock = sync!();
+
+    let src = r#"
+    fn test() {
+        let x = 8;
+        ~
+        let y = 55;
+    }
+    "#;
+
+    let completions = get_all_completions(src, None);
+    assert!(completions.into_iter().any(|m| m.matchstr == "std"));
+}


### PR DESCRIPTION
Autocomplete doesn't work in position between a block opening and a statement

You can check out the first commit of this PR and run `cargo test` in order to observe the issue. Relevant part of `cargo test` output:

```
failures:

---- completes_between_statements stdout ----
        thread 'completes_between_statements' panicked at 'begin <= end (53 <= 44) when slicing `
    fn test() {
        let x = 8;

        let y = 55;
    }
    `', libcore/str/mod.rs:2225:5

---- completes_before_first_statement stdout ----
        thread 'completes_before_first_statement' panicked at 'begin <= end (34 <= 25) when slicing `
    fn test() {

        let x = 8;
    }
    `', libcore/str/mod.rs:2225:5
```