### PR TITLE
Cache parsed TOML and cargo crate roots - 10x speed for standalone use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ toml = "0.4"
 env_logger = "0.5"
 clap = "2.19"
 lazy_static = "1.0"
+humantime = "1.1"
 
 [dependencies.clippy]
 version = "0.0.103"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,11 +3,13 @@ extern crate env_logger;
 #[macro_use] extern crate clap;
 
 extern crate racer;
+extern crate humantime;
 
 use racer::{Match, MatchType, FileCache, Session, Coordinate, Point};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::io::{self, BufRead, Read};
+use std::time::SystemTime;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 fn point(cfg: Config) {
@@ -462,16 +464,26 @@ fn build_cli<'a, 'b>() -> App<'a, 'b> {
 }
 
 fn main() {
-    env_logger::init();
+    use std::io::Write;
+
+    env_logger::Builder::from_default_env()
+        .format(|f, record| {
+            writeln!(f, "{:>5} {}: {}: {}",
+                     record.level(),
+                     humantime::format_rfc3339_nanos(SystemTime::now()),
+                     record.module_path().unwrap_or("-"),
+                     record.args())
+        })
+        .init();
 
     let matches = build_cli().get_matches();
     let interface = match matches.value_of("interface") {
             Some("tab-text") => Interface::TabText,
             Some("text") | _ => Interface::Text
         };
-    
+
     validate_rust_src_path_env_var();
-    
+
     run(matches, interface);
 }
 

--- a/src/racer/benches.rs
+++ b/src/racer/benches.rs
@@ -1,17 +1,16 @@
-#![feature(test)]
 extern crate test;
-extern crate racer;
 
-use racer::codecleaner::code_chunks;
-use racer::codeiter::iter_stmts;
-use racer::scopes::{mask_comments, mask_sub_scopes};
-use racer::core::IndexedSource;
-
-use self::test::Bencher;
 use std::env::var;
 use std::io::Read;
 use std::fs::File;
 use std::path::PathBuf;
+
+use codeiter::StmtIndicesIter;
+use codecleaner::code_chunks;
+use scopes::{mask_comments, mask_sub_scopes};
+use core::IndexedSource;
+
+use self::test::Bencher;
 
 fn get_rust_file_str(path: &[&str]) -> String {
     let mut src_path = match var("RUST_SRC_PATH") {
@@ -27,7 +26,7 @@ fn get_rust_file_str(path: &[&str]) -> String {
 
 #[bench]
 fn bench_code_chunks(b: &mut Bencher) {
-    let src = &get_rust_file_str(&["libcollections", "vec.rs"]);
+    let src = &get_rust_file_str(&["liballoc", "vec.rs"]);
     b.iter(|| {
         test::black_box(code_chunks(src).collect::<Vec<_>>());
     });
@@ -35,15 +34,16 @@ fn bench_code_chunks(b: &mut Bencher) {
 
 #[bench]
 fn bench_iter_stmts(b: &mut Bencher) {
-    let src = &get_rust_file_str(&["libcollections", "vec.rs"]);
+    let src = &get_rust_file_str(&["liballoc", "vec.rs"]);
     b.iter(|| {
-        test::black_box(iter_stmts(src).collect::<Vec<_>>());
+        test::black_box(StmtIndicesIter::from_parts(src, code_chunks(src))
+                        .collect::<Vec<_>>());
     });
 }
 
 #[bench]
 fn bench_mask_comments(b: &mut Bencher) {
-    let src_indexed = IndexedSource::new(get_rust_file_str(&["libcollections", "vec.rs"]));
+    let src_indexed = IndexedSource::new(get_rust_file_str(&["liballoc", "vec.rs"]));
     let src = src_indexed.as_src();
     b.iter(|| {
         test::black_box(mask_comments(src));
@@ -52,7 +52,7 @@ fn bench_mask_comments(b: &mut Bencher) {
 
 #[bench]
 fn bench_mask_sub_scopes(b: &mut Bencher) {
-    let src = &get_rust_file_str(&["libcollections", "vec.rs"]);
+    let src = &get_rust_file_str(&["liballoc", "vec.rs"]);
     b.iter(|| {
         test::black_box(mask_sub_scopes(src));
     });

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -627,7 +627,7 @@ fn get_crate_file_from_overrides<P>(crate_name: &str, path: P) -> Option<PathBuf
     // For each .cargo/config file
     for cargo_config in CargoOverrides(path) {
         // For each path in .cargo/config `paths`
-        for override_path in get_override_paths(cargo_config.as_path()).into_iter() {
+        for override_path in get_override_paths(cargo_config.as_path()) {
             trace!("examining override_path={:?}", override_path);
             let mut path = PathBuf::from(override_path);
 

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -8,6 +8,36 @@ use std::time::SystemTime;
 use std::collections::HashMap;
 use toml;
 
+// otry is 'option try'
+macro_rules! otry {
+    ($e:expr) => {
+        match $e {
+            Some(e) => e,
+            None => return None
+        }
+    }
+}
+
+// converts Err into None, while logging an error
+macro_rules! otry2 {
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => { error!("ERROR!: {:?} {} {}", e, file!(), line!()); return None }
+        }
+    }
+}
+
+// converts errors into message + empty vec
+macro_rules! vectry {
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => { error!("ERROR!: {:?} {} {}", e, file!(), line!()); return Vec::new() }
+        }
+    }
+}
+
 thread_local! {
     /// Caches parsed Cargo.toml/Cargo.lock files, together with the mtime for
     /// invalidation.
@@ -18,124 +48,7 @@ thread_local! {
         Default::default();
 }
 
-#[derive(Debug)]
-struct PackageInfo {
-    name: String,
-    version: Option<String>,
-    source: Option<PathBuf>
-}
-
-// otry is 'option try'
-macro_rules! otry {
-    ($e:expr) => (match $e { Some(e) => e, None => return None })
-}
-
-// converts errors into None
-macro_rules! otry2 {
-    ($e:expr) => (match $e { Ok(e) => e, Err(e) => { error!("ERROR!: {:?} {} {}", e, file!(), line!()); return None } })
-}
-
-// converts errors into message + empty vec
-macro_rules! vectry {
-    ($e:expr) => (match $e { Ok(e) => e, Err(e) => { error!("ERROR!: {:?} {} {}", e, file!(), line!()); return Vec::new() } })
-}
-
-/// Gets the branch from a git source string if one is present.
-fn get_branch_from_source(source: &str) -> Option<&str> {
-    debug!("get_branch_from_source - Finding branch from {:?}", source);
-    match source.find("branch=") {
-        Some(idx) => {
-            let (_start, branch) = source.split_at(idx+7);
-            match branch.find('#') {
-                Some(idx) => {
-                    let (branch, _end) = branch.split_at(idx);
-                    Some(branch)
-                },
-                None => Some(branch),
-            }
-        },
-        None => None
-    }
-}
-
-/// Gets the repository_name from a git source string if one is present.
-fn get_repository_name_from_source(source: &str) -> Option<&str> {
-    debug!("get_repository_name_from_source - Finding repository name from {:?}", source);
-    match source.rfind("/") {
-        Some(idx) => {
-            let (_, mut repository_name) = source.split_at(idx + 1);
-            let mut idx =  repository_name.find("?").unwrap_or_else(|| {
-                repository_name.find("#").unwrap_or(0)
-            });
-            if idx == 0 {
-                return None;
-            }
-            repository_name = &repository_name[0..idx];
-            idx = repository_name.find(".git").unwrap_or(0);
-            if idx == 0 {
-                return Some(repository_name);
-            }
-            repository_name = &repository_name[0..idx];
-            Some(repository_name)
-        },
-        None => None
-    }
-}
-
-#[test]
-fn gets_repository_name_from_source() {
-    let source = "git+https://github.com/phildawes/racer.git?branch=dev#9e04f91f0426c1cf8ec5e5023f74d7261f5a9dd1";
-    let repository_name = get_repository_name_from_source(source);
-    assert_eq!(repository_name, Some("racer"));
-}
-
-#[test]
-fn gets_branch_from_git_source_with_hash() {
-    let source = "git+https://github.com/phildawes/racer.git?branch=dev#9e04f91f0426c1cf8ec5e5023f74d7261f5a9dd1";
-    let branch = get_branch_from_source(source);
-    assert_eq!(branch, Some("dev"));
-}
-
-#[test]
-fn gets_branch_from_git_source_without_hash() {
-    let source = "git+https://github.com/phildawes/racer.git?branch=dev";
-    let branch = get_branch_from_source(source);
-    assert_eq!(branch, Some("dev"));
-}
-
-#[test]
-fn empty_if_no_branch() {
-    let source = "git+https://github.com/phildawes/racer.git#9e04f91f0426c1cf8ec5e5023f74d7261f5a9dd1";
-    let branch = get_branch_from_source(source);
-    assert_eq!(branch, None);
-}
-
-fn find_src_via_lockfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
-    trace!("find_src_via_lockfile searching for {} in {:?}", kratename, cargofile);
-    if let Some(packages) = get_cargo_packages(cargofile) {
-        trace!("find_src_via_lockfile got packages");
-        for package in packages {
-            trace!("find_src_via_lockfile examining {:?}", package);
-            if let Some(package_source) = package.source {
-                trace!("find_src_via_lockfile package_source {:?}", package_source);
-                if let Some(tomlfile) = find_cargo_tomlfile(package_source.clone()) {
-                    trace!("find_src_via_lockfile tomlfile {:?}", tomlfile);
-                    let package_name = get_package_name(tomlfile.as_path());
-
-                    debug!("find_src_via_lockfile package_name: {}", package_name);
-
-                    if package_name == kratename {
-                        return Some(package_source);
-                    }
-                }
-            }
-        }
-    }
-
-    trace!("find_src_via_lockfile returning None");
-    None
-}
-
+/// Parse and cache a TOML file (Cargo.toml or Cargo.lock).
 fn parse_toml_file(toml_file: &Path) -> Option<Rc<toml::Value>> {
     TOML_CACHE.with(|cache| {
         let mtime = otry!(fs::metadata(toml_file).ok().and_then(|m| m.modified().ok()));
@@ -158,10 +71,64 @@ fn parse_toml_file(toml_file: &Path) -> Option<Rc<toml::Value>> {
     })
 }
 
-fn get_cargo_packages(cargofile: &Path) -> Option<Vec<PackageInfo>> {
-    let lock_table = parse_toml_file(cargofile).unwrap();
+#[derive(Debug)]
+struct PackageInfo {
+    name: String,
+    version: Option<String>,
+    source: Option<PathBuf>
+}
 
-    debug!("get_cargo_packages found lock_table {}: {:?}", cargofile.display(), lock_table);
+/// Gets the branch from a git source string if one is present.
+fn get_branch_from_source(source: &str) -> Option<&str> {
+    debug!("get_branch_from_source - Finding branch from {:?}", source);
+    source.find("branch=").and_then(|idx| {
+        let branch = &source[idx+7..];
+        branch.find('#').map(|idx| &branch[..idx]).or(Some(branch))
+    })
+}
+
+/// Gets the repository_name from a git source string if one is present.
+fn get_repository_name_from_source(source: &str) -> Option<&str> {
+    debug!("get_repository_name_from_source - Finding repository name from {:?}", source);
+    source.rfind('/').and_then(|idx| {
+        let repository_name = &source[idx+1..];
+        repository_name.find(&['?', '#'][..])
+            .map(|idx| repository_name[0..idx].trim_right_matches(".git"))
+    })
+}
+
+/// Find the main package file for a given crate, given a Cargo.lock file location.
+fn find_src_via_lockfile(cratename: &str, lockfile: &Path) -> Option<PathBuf> {
+    trace!("find_src_via_lockfile searching for {} in {:?}", cratename, lockfile);
+    if let Some(packages) = get_cargo_packages(lockfile) {
+        trace!("find_src_via_lockfile got packages");
+        for package in packages {
+            trace!("find_src_via_lockfile examining {:?}", package);
+            if let Some(package_source) = package.source {
+                trace!("find_src_via_lockfile package_source {:?}", package_source);
+                if let Some(tomlfile) = find_cargo_tomlfile(&package_source) {
+                    trace!("find_src_via_lockfile tomlfile {:?}", tomlfile);
+                    let package_name = get_package_name(&tomlfile);
+
+                    debug!("find_src_via_lockfile package_name: {}", package_name);
+
+                    if package_name == cratename {
+                        return Some(package_source);
+                    }
+                }
+            }
+        }
+    }
+
+    trace!("find_src_via_lockfile returning None");
+    None
+}
+
+/// Extract all dependency packages from a Cargo.lock file.
+fn get_cargo_packages(lockfile: &Path) -> Option<Vec<PackageInfo>> {
+    let lock_table = otry!(parse_toml_file(lockfile));
+
+    debug!("get_cargo_packages found lock_table {}: {:?}", lockfile.display(), lock_table);
 
     let packages_array = match lock_table.get("package") {
         Some(&toml::Value::Array(ref t1)) => t1,
@@ -192,37 +159,34 @@ fn get_cargo_packages(cargofile: &Path) -> Option<Vec<PackageInfo>> {
 
                 let package_source = match package_source.split('+').nth(0) {
                     Some("registry") => {
-                        get_versioned_cratefile(package_name, &package_version, cargofile)
+                        get_versioned_cratefile(package_name, &package_version)
                     },
                     Some("git") => {
                         let sha1 = unwrap_or_continue!(package_source.split('#').last());
-                        let mut d = unwrap_or_continue!(get_cargo_rootdir(cargofile));
                         let branch = get_branch_from_source(&package_source);
-                        d.push("git");
-                        d.push("checkouts");
 
                         // use repository name instead of package name
-                        d = match get_repository_name_from_source(&package_source) {
+                        let mut dir = match get_repository_name_from_source(&package_source) {
                             Some(repo_name) => {
-                                unwrap_or_continue!(find_git_src_dir(d, repo_name, &sha1, branch))
+                                unwrap_or_continue!(find_git_src_dir(repo_name, &sha1, branch))
                             }
                             None => {
-                                unwrap_or_continue!(find_git_src_dir(d, package_name, &sha1, branch))
+                                unwrap_or_continue!(find_git_src_dir(package_name, &sha1, branch))
                             }
                         };
 
-                        d.push("src");
-                        d.push("lib.rs");
-
-                        Some(d)
+                        // TODO: this is not necessarily correct
+                        dir.push("src");
+                        dir.push("lib.rs");
+                        Some(dir)
                     },
                     _ => return None
                 };
 
-                result.push(PackageInfo{
-                    name: package_name.to_owned(),
+                result.push(PackageInfo {
+                    name: package_name.clone(),
                     version: Some(package_version),
-                    source: package_source
+                    source: package_source,
                 });
             }
         }
@@ -230,119 +194,106 @@ fn get_cargo_packages(cargofile: &Path) -> Option<Vec<PackageInfo>> {
     Some(result)
 }
 
-fn get_package_name(cargofile: &Path) -> String {
-    let lock_table = match parse_toml_file(cargofile) {
-        Some(t) => t,
-        None => return String::new(),
-    };
+/// Extract the package name from a Cargo.toml file.
+fn get_package_name(cargotomlfile: &Path) -> String {
+    if let Some(cargo_table) = parse_toml_file(cargotomlfile) {
+        debug!("get_package_name found cargo_table {}: {:?}", cargotomlfile.display(), cargo_table);
 
-    debug!("get_package_name found lock_table {}: {:?}", cargofile.display(), lock_table);
-
-    if let Some(&toml::Value::Table(ref lib_table)) = lock_table.get("lib") {
-        if let Some(&toml::Value::String(ref package_name)) = lib_table.get("name") {
-            return package_name.clone();
+        if let Some(&toml::Value::Table(ref lib_table)) = cargo_table.get("lib") {
+            if let Some(&toml::Value::String(ref package_name)) = lib_table.get("name") {
+                return package_name.clone();
+            }
         }
-    }
 
-    if let Some(&toml::Value::Table(ref package_table)) = lock_table.get("package") {
-        if let Some(&toml::Value::String(ref package_name)) = package_table.get("name") {
-            return package_name.replace("-","_");
+        if let Some(&toml::Value::Table(ref package_table)) = cargo_table.get("package") {
+            if let Some(&toml::Value::String(ref package_name)) = package_table.get("name") {
+                return package_name.replace('-', "_");
+            }
         }
     }
 
     String::new()
 }
 
-fn get_cargo_rootdir(cargofile: &Path) -> Option<PathBuf> {
-    debug!("get_cargo_rootdir. {:?}",cargofile);
-
-    if let Some(cargohome) = env::var_os("CARGO_HOME") {
-        debug!("get_cargo_rootdir. CARGO_HOME is set: {:?}",cargohome);
-
-        let d = PathBuf::from(cargohome);
-
-        if d.exists() {
-            return Some(d)
-        } else {
-            return None
-        };
-    }
-
-    let mut d = otry!(env::home_dir());
-
-    d.push(".cargo");
-    if d.exists() {
-        Some(d)
+/// Find the Cargo "root" directory, where Cargo dependencies are unpacked/checked out.
+fn get_cargo_rootdir() -> Option<PathBuf> {
+    let dir = if let Some(cargo_home) = env::var_os("CARGO_HOME") {
+        debug!("get_cargo_rootdir: CARGO_HOME is set: {:?}", cargo_home);
+        PathBuf::from(cargo_home)
+    } else {
+        debug!("get_cargo_rootdir: no CARGO_HOME");
+        otry!(env::home_dir()).join(".cargo")
+    };
+    if dir.exists() {
+        Some(dir)
     } else {
         None
     }
 }
 
-fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> Option<PathBuf> {
-    trace!("get_versioned_cratefile searching for {}", kratename);
-    let mut d = otry!(get_cargo_rootdir(cargofile));
+/// Find the main package file for a crate with given name/version from CARGO_HOME.
+fn get_versioned_cratefile(cratename: &str, version: &str) -> Option<PathBuf> {
+    trace!("get_versioned_cratefile searching for {}", cratename);
+    let mut dir = otry!(get_cargo_rootdir());
 
-    debug!("get_versioned_cratefile: cargo rootdir is {:?}",d);
-    d.push("registry");
-    d.push("src");
+    debug!("get_versioned_cratefile: cargo rootdir is {:?}", dir);
+    dir.push("registry");
+    dir.push("src");
 
-    for mut d in find_cratesio_src_dirs(d) {
-
-        // if version=* then search for the first matching folder
+    for mut src in find_cratesio_src_dirs(&dir) {
+        // if version = * then search for the first matching folder
         if version == "*" {
-            let mut start_path = d.clone();
-            start_path.push(kratename);
-            let start_name = start_path.to_str().unwrap();
+            let start = format!("{}-", cratename);
 
-            if let Ok(reader) = fs::read_dir(d) {
-                if let Some(path) = reader
-                    .map(|entry| entry.unwrap().path())
-                    .find(|path| path.to_str().unwrap().starts_with(start_name)) {
-                        d = path.clone();
-                    } else {
-                        continue;
-                    }
+            if let Some(entry) = fs::read_dir(&src).ok().and_then(|reader| {
+                reader
+                    .filter_map(|entry| entry.ok())
+                    .find(|e| e.file_name().to_str().unwrap().starts_with(&start))
+            }) {
+                src = entry.path();
             } else {
                 continue;
             }
         } else {
-            d.push(kratename.to_owned() + "-" + version);
+            src.push(format!("{}-{}", cratename, version));
         }
 
-        d.push("src");
-        debug!("crate path {:?}",d);
+        debug!("crate path {:?}", src);
 
-        // First, check for package name at root (src/kratename/lib.rs)
-        d.push(kratename);
-        d.push("lib.rs");
-        if let Err(_) = File::open(&d) {
+        // TODO: this doesn't catch all possible cases
+
+        // First, check for package name at root (src/cratename/lib.rs)
+        src.push("src");
+        src.push(cratename);
+        src.push("lib.rs");
+        if !src.exists() {
             // It doesn't exist, so assume src/lib.rs
-            d.pop();
-            d.pop();
-            d.push("lib.rs");
+            src.pop();
+            src.pop();
+            src.push("lib.rs");
         }
-        debug!("crate path with lib.rs {:?}",d);
+        debug!("crate path with lib.rs {:?}", src);
 
-        if let Err(_) = File::open(&d) {
-            trace!("failed to open crate path {:?}", d);
+        if !src.exists() {
+            trace!("failed to open crate path {:?}", src);
             // It doesn't exist, so try /lib.rs
-            d.pop();
-            d.pop();
-            d.push("lib.rs");
+            src.pop();
+            src.pop();
+            src.push("lib.rs");
         }
 
-        if let Err(_) = File::open(&d) {
-            trace!("failed to open crate path {:?}", d);
+        if !src.exists() {
+            trace!("failed to open crate path {:?}", src);
             continue;
         }
 
-        return Some(d)
+        return Some(src);
     }
     None
  }
 
-/// Return path to library source if the Cargo.toml name matches crate_name
-fn path_if_desired_lib(crate_name: &str, path: &Path, cargo_toml: &toml::Value) -> Option<PathBuf> {
+/// Return path to library source if the Cargo.toml name matches cratename.
+fn path_if_desired_lib(cratename: &str, path: &Path, cargo_toml: &toml::Value) -> Option<PathBuf> {
     let parent = otry!(path.parent());
 
     // is it this lib?  (e.g. you're searching from tests to find the main library crate)
@@ -351,7 +302,7 @@ fn path_if_desired_lib(crate_name: &str, path: &Path, cargo_toml: &toml::Value) 
         .and_then(|package| package.get("name"))
         .and_then(|name| name.as_str()));
 
-    let mut lib_name = package_name.replace("-", "_");
+    let mut lib_name = package_name.replace('-', "_");
     let mut lib_path = parent.join("src").join("lib.rs");
 
     if let Some(&toml::Value::Table(ref t)) = cargo_toml.get("lib") {
@@ -365,8 +316,8 @@ fn path_if_desired_lib(crate_name: &str, path: &Path, cargo_toml: &toml::Value) 
         }
     }
 
-    if lib_name == crate_name {
-        debug!("found {} as lib entry in Cargo.toml", crate_name);
+    if lib_name == cratename {
+        debug!("found {} as lib entry in Cargo.toml", cratename);
 
         if fs::metadata(&lib_path).ok().map_or(false, |m| m.is_file()) {
             return Some(lib_path);
@@ -376,20 +327,21 @@ fn path_if_desired_lib(crate_name: &str, path: &Path, cargo_toml: &toml::Value) 
     None
 }
 
-fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
-    trace!("find_src_via_tomlfile looking for {}", kratename);
+/// Find the main package file for a given crate, given a Cargo.toml file location.
+fn find_src_via_tomlfile(cratename: &str, cargotomlfile: &Path) -> Option<PathBuf> {
+    trace!("find_src_via_tomlfile looking for {}", cratename);
     // only look for 'path' references here.
     // We find the git and crates.io stuff via the lockfile
-    let table = otry!(parse_toml_file(cargofile));
+    let table = otry!(parse_toml_file(cargotomlfile));
 
-    // Check if current cargo file is for requested library
-    if let Some(lib_path) = path_if_desired_lib(kratename, cargofile, &table) {
+    // check if current cargo file is for requested library
+    if let Some(lib_path) = path_if_desired_lib(cratename, cargotomlfile, &table) {
         return Some(lib_path);
     }
 
     // otherwise search the dependencies
-    let local_packages = get_local_packages(&table, cargofile, "dependencies").unwrap_or_default();
-    let local_packages_dev = get_local_packages(&table, cargofile, "dev-dependencies").unwrap_or_default();
+    let local_packages = get_local_packages(&table, cargotomlfile, "dependencies").unwrap_or_default();
+    let local_packages_dev = get_local_packages(&table, cargotomlfile, "dev-dependencies").unwrap_or_default();
 
     // if no dependencies are found
     if local_packages.is_empty() && local_packages_dev.is_empty() {
@@ -403,12 +355,12 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
     for package in local_packages.into_iter().chain(local_packages_dev) {
         if let Some(package_source) = package.source {
             if let Some(tomlfile) = find_cargo_tomlfile(package_source) {
-                let package_name = get_package_name(tomlfile.as_path());
+                let package_name = get_package_name(&tomlfile);
 
                 debug!("find_src_via_tomlfile package_name: {}", package_name);
 
-                if package_name == kratename {
-                    return find_src_via_tomlfile(kratename, &tomlfile)
+                if package_name == cratename {
+                    return find_src_via_tomlfile(cratename, &tomlfile)
                 }
             }
         }
@@ -416,11 +368,12 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
     None
 }
 
-fn get_local_packages(table: &toml::Value, cargofile: &Path, section_name: &str) -> Option<Vec<PackageInfo>> {
-    debug!("get_local_packages found table {:?};\
-           getting packages for section '{}'", table, section_name);
+/// Find dependencies given a Cargo.toml section (dependencies or dev-dependencies).
+fn get_local_packages(table: &toml::Value, cargotomlfile: &Path, section_name: &str) -> Option<Vec<PackageInfo>> {
+    debug!("get_local_packages found table {:?}; \
+            getting packages for section '{}'", table, section_name);
 
-    let t = match table.get(section_name) {
+    let dep_table = match table.get(section_name) {
         Some(&toml::Value::Table(ref t)) => t,
         _ => {
             trace!("get_local_packages didn't find section {}", section_name);
@@ -429,24 +382,26 @@ fn get_local_packages(table: &toml::Value, cargofile: &Path, section_name: &str)
     };
 
     let mut result = Vec::new();
+    let parent = otry!(cargotomlfile.parent());
 
-    let parent = otry!(cargofile.parent());
-
-    for (package_name, value) in t.iter() {
+    for (package_name, value) in dep_table {
         let mut package_version = None;
 
         let package_source = match *value {
             toml::Value::Table(ref t) => {
                 if let Some(relative_path) = getstr(t, "path") {
+                    // TODO: this path isn't necessarily correct
                     Some(parent.join(relative_path).join("src").join("lib.rs"))
                 } else {
+                    // TODO: can also contain "git" references checked out
+                    // in CARGO_HOME
                     continue
                 }
             },
             toml::Value::String(ref version) => {
                 // versioned crate
                 package_version = Some(version.to_owned());
-                get_versioned_cratefile(package_name, version, cargofile)
+                get_versioned_cratefile(package_name, version)
             },
             _ => {
                 trace!("get_local_packages couldn't find package_source for {}", package_name);
@@ -457,81 +412,81 @@ fn get_local_packages(table: &toml::Value, cargofile: &Path, section_name: &str)
         result.push(PackageInfo {
             name: package_name.to_owned(),
             version: package_version,
-            source: package_source
+            source: package_source,
         });
     }
 
     Some(result)
 }
 
-fn find_cratesio_src_dirs(d: PathBuf) -> Vec<PathBuf> {
+/// Find all directories with unpacked sources from crates.io.
+fn find_cratesio_src_dirs(dir: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    for entry in vectry!(fs::read_dir(d)) {
+    for entry in vectry!(fs::read_dir(dir)) {
         let path = vectry!(entry).path();
         if path.is_dir() {
-            if let Some(fname) = path.file_name().and_then(|s| s.to_str()) {
-                if fname.starts_with("github.com-") {
-                    out.push(path.clone());
-                }
+            if path.file_name()
+                .and_then(|s| s.to_str())
+                .map_or(false, |fname| fname.starts_with("github.com-"))
+            {
+                out.push(path);
             }
         }
     }
     out
 }
 
-fn find_git_src_dir(d: PathBuf, name: &str, sha1: &str, branch: Option<&str>) -> Option<PathBuf> {
-    for entry in otry2!(fs::read_dir(d)) {
-        let path = otry2!(entry).path();
-        if path.is_dir() {
-            if let Some(fname) = path.file_name().and_then(|s| s.to_str()) {
-                if fname.starts_with(name) {
-                    let mut d = path.clone();
+/// Find a checked out Git repository under CARGO_HOME.
+fn find_git_src_dir(name: &str, sha1: &str, branch: Option<&str>) -> Option<PathBuf> {
+    let mut dir = otry!(get_cargo_rootdir());
+    dir.push("git");
+    dir.push("checkouts");
+    for entry in otry2!(fs::read_dir(&dir)) {
+        let mut dir = otry2!(entry).path();
+        if !dir.is_dir() {
+            continue;
+        }
+        if dir.file_name().and_then(|s| s.to_str()).map_or(false, |fname| fname.starts_with(name)) {
+            // dirname can be the sha1 or master.
+            dir.push(sha1);
 
-                    // dirname can be the sha1 or master.
-                    d.push(sha1);
+            if !dir.is_dir() {
+                dir.pop();
+                dir.push(&sha1[0..7]);
+            }
 
-                    if !d.is_dir() {
-                        d.pop();
-                        d.push(&sha1[0..7]);
-                    }
+            if !dir.is_dir() && branch.is_some() {
+                dir.pop();
+                dir.push(branch.unwrap());
+            }
 
-                    if !d.is_dir() && branch.is_some() {
-                        d.pop();
-                        d.push(branch.unwrap());
-                    }
+            if !dir.is_dir() {
+                dir.pop();
+                dir.push("master");
+            }
 
-                    if !d.is_dir() {
-                        d.pop();
-                        d.push("master");
-                    }
+            // check that the checkout matches the commit sha1
+            let mut check_file = dir.clone();
+            check_file.push(".git");
+            check_file.push("refs");
+            check_file.push("heads");
+            check_file.push("master");
 
-                    let retval = d.clone();
+            let mut headref = String::new();
+            // TODO: use fs::read_to_string when available
+            otry2!(otry2!(File::open(&check_file)).read_to_string(&mut headref));
 
-                    // check that the checkout matches the commit sha1
-                    d.push(".git");
-                    d.push("refs");
-                    d.push("heads");
-                    d.push("master");
+            debug!("git headref is {:?}", headref);
 
-                    let mut headref = String::new();
-                    otry2!(otry2!(File::open(d)).read_to_string(&mut headref));
-
-                    debug!("git headref is {:?}", headref);
-
-                    if headref.ends_with('\n') {
-                        headref.pop();
-                    }
-
-                    if sha1 == headref {
-                        return Some(retval);
-                    }
-                }
+            if sha1 == headref.trim_right() {
+                return Some(dir);
             }
         }
     }
     None
 }
 
+/// Get and clone a string from a TOML table.
 fn getstr(t: &toml::value::Table, k: &str) -> Option<String> {
     match t.get(k) {
         Some(&toml::Value::String(ref s)) => Some(s.clone()),
@@ -539,14 +494,22 @@ fn getstr(t: &toml::value::Table, k: &str) -> Option<String> {
     }
 }
 
-#[inline]
-fn find_cargo_tomlfile<P>(file: P) -> Option<PathBuf>
+/// Find Cargo.toml in crate root by traversing up the directory tree searching.
+///
+/// Any directory that contains a Cargo.toml is considered to be a crate root.
+/// If the provided `path` contains a Cargo.toml, that path is returned.
+fn find_cargo_tomlfile<P>(path: P) -> Option<PathBuf>
     where P: Into<PathBuf>
 {
-    find_next_crate_root(file).map(|mut f| {
-        f.push("Cargo.toml");
-        f
-    })
+    let mut path = path.into();
+    path.push("Cargo.toml");
+    if path.exists() {
+        Some(path)
+    } else if path.pop() && path.pop() {
+        find_cargo_tomlfile(path)
+    } else {
+        None
+    }
 }
 
 /// Find workspace root by traversing up the directory tree
@@ -573,25 +536,7 @@ fn find_workspace_root<P>(path: P) -> Option<PathBuf>
     }
 }
 
-/// Find crate root by traversing up the directory tree searching
-///
-/// Any directory that contains a Cargo.toml is considered to be a crate root.
-/// If the provided `path` contains a Cargo.toml, that path is returned.
-fn find_next_crate_root<P>(path: P) -> Option<PathBuf>
-    where P: Into<PathBuf>
-{
-    let mut path = path.into();
-    path.push("Cargo.toml");
-    if path.exists() {
-        path.pop();
-        Some(path)
-    } else if path.pop() && path.pop() {
-        find_next_crate_root(path)
-    } else {
-        None
-    }
-}
-
+/// Retrieve the Cargo override paths from a TOML config file at the given path.
 fn get_override_paths(path: &Path) -> Vec<String> {
     parse_toml_file(path)
         .as_ref()
@@ -646,16 +591,16 @@ impl Iterator for CargoOverrides {
 ///
 /// The path to `crate_name`'s library root will be returned if a match is
 /// found.
-fn get_crate_file_from_overrides<P>(crate_name: &str, path: P) -> Option<PathBuf>
+fn get_crate_file_from_overrides<P>(cratename: &str, path: P) -> Option<PathBuf>
     where P: Into<PathBuf>
 {
     let path = path.into();
-    trace!("get_crate_file_from_overrides; crate_name={:?}, path={:?}", crate_name, path);
+    trace!("get_crate_file_from_overrides; cratename={:?}, path={:?}", cratename, path);
 
     // For each .cargo/config file
     for cargo_config in CargoOverrides(path) {
         // For each path in .cargo/config `paths`
-        for override_path in get_override_paths(cargo_config.as_path()) {
+        for override_path in get_override_paths(&cargo_config) {
             trace!("examining override_path={:?}", override_path);
             let mut path = PathBuf::from(override_path);
 
@@ -684,7 +629,7 @@ fn get_crate_file_from_overrides<P>(crate_name: &str, path: P) -> Option<PathBuf
 
             // Read cargo file and see if it's the crate we need.
             if let Some(toml) = parse_toml_file(path.as_path()) {
-                if let Some(lib_path) = path_if_desired_lib(crate_name, path.as_path(), &toml) {
+                if let Some(lib_path) = path_if_desired_lib(cratename, path.as_path(), &toml) {
                     return Some(lib_path);
                 } else {
                     trace!("not desired lib");
@@ -698,29 +643,31 @@ fn get_crate_file_from_overrides<P>(crate_name: &str, path: P) -> Option<PathBuf
     None
 }
 
-pub fn get_crate_file(kratename: &str, from_path: &Path) -> Option<PathBuf> {
+/// Main public entry point: Retrieve the main crate file for a given crate,
+/// in the context of the crate at from_path.
+pub fn get_crate_file(cratename: &str, from_path: &Path) -> Option<PathBuf> {
     debug!("get_crate_file: from_path={:?}", from_path);
-    if let Some(src) = get_crate_file_from_overrides(kratename, from_path) {
+
+    let from_path = from_path.canonicalize().unwrap_or_else(|_| from_path.into());
+
+    if let Some(src) = get_crate_file_from_overrides(cratename, &from_path) {
         return Some(src);
     }
 
-    if let Some(tomlfile) = find_cargo_tomlfile(from_path.to_path_buf()) {
+    if let Some(cargotomlfile) = find_cargo_tomlfile(&from_path) {
         // look in the lockfile first, if there is one
         // also search workspaces for a lockfile
-        trace!("get_crate_file tomlfile is {:?}", tomlfile);
+        trace!("get_crate_file tomlfile is {:?}", cargotomlfile);
 
-        let absolute_path = env::current_dir().unwrap().join(from_path);
-        let workspace = find_workspace_root(absolute_path);
-
-        let mut lockfile = tomlfile.clone();
-        lockfile.pop();
-        if let Some(workspace) = workspace {
-            lockfile = workspace;
-            trace!("get_crate_file workspace is {:?}", lockfile);
-        }
+        let mut lockfile = find_workspace_root(&from_path).unwrap_or_else(|| {
+            let mut dir = cargotomlfile.clone();
+            dir.pop();
+            dir
+        });
         lockfile.push("Cargo.lock");
+
         if lockfile.exists() {
-            if let Some(f) = find_src_via_lockfile(kratename, &lockfile) {
+            if let Some(f) = find_src_via_lockfile(cratename, &lockfile) {
                 return Some(f);
             }
         } else {
@@ -728,7 +675,7 @@ pub fn get_crate_file(kratename: &str, from_path: &Path) -> Option<PathBuf> {
         }
 
         // oh, no luck with the lockfile. Try the tomlfile
-        return find_src_via_tomlfile(kratename, &tomlfile);
+        return find_src_via_tomlfile(cratename, &cargotomlfile);
     }
     None
 }
@@ -754,5 +701,33 @@ mod tests {
             .expect("finds arst/src/lib.rs");
         assert_eq!(actual.canonicalize().expect("canonicalize path"),
          expected.canonicalize().expect("canonicalize path"));
+    }
+
+    #[test]
+    fn gets_repository_name_from_source() {
+        let source = "git+https://github.com/phildawes/racer.git?branch=dev#9e04f91f0426c1cf8ec5e5023f74d7261f5a9dd1";
+        let repository_name = super::get_repository_name_from_source(source);
+        assert_eq!(repository_name, Some("racer"));
+    }
+
+    #[test]
+    fn gets_branch_from_git_source_with_hash() {
+        let source = "git+https://github.com/phildawes/racer.git?branch=dev#9e04f91f0426c1cf8ec5e5023f74d7261f5a9dd1";
+        let branch = super::get_branch_from_source(source);
+        assert_eq!(branch, Some("dev"));
+    }
+
+    #[test]
+    fn gets_branch_from_git_source_without_hash() {
+        let source = "git+https://github.com/phildawes/racer.git?branch=dev";
+        let branch = super::get_branch_from_source(source);
+        assert_eq!(branch, Some("dev"));
+    }
+
+    #[test]
+    fn empty_if_no_branch() {
+        let source = "git+https://github.com/phildawes/racer.git#9e04f91f0426c1cf8ec5e5023f74d7261f5a9dd1";
+        let branch = super::get_branch_from_source(source);
+        assert_eq!(branch, None);
     }
 }

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -813,7 +813,7 @@ impl<'c> Session<'c> {
     /// 1. overrides
     /// 2. lock file
     /// 3. toml file
-    pub fn get_crate_file(&self, kratename: &str, from_path: &path::Path) -> Option<path::PathBuf> {
+    pub(crate) fn get_crate_file(&self, kratename: &str, from_path: &path::Path) -> Option<path::PathBuf> {
         self.cargo_roots.borrow_mut().entry((kratename.into(), from_path.into()))
             .or_insert_with(|| cargo::get_crate_file(kratename, from_path))
             .clone()

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -18,6 +18,7 @@ use nameres;
 use ast;
 use codecleaner;
 use util;
+use cargo;
 
 /// Within a [`Match`], specifies what was matched
 ///
@@ -743,6 +744,8 @@ pub struct Session<'c> {
     pub generic_impls: RefCell<HashMap<(path::PathBuf, usize),
                                        Rc<Vec<(usize, String,
                                                ast::GenericsVisitor, ast::ImplVisitor)>>>>,
+    /// Cache for crate roots
+    cargo_roots: RefCell<HashMap<(String, path::PathBuf), Option<path::PathBuf>>>,
 }
 
 impl<'c> fmt::Debug for Session<'c> {
@@ -771,6 +774,7 @@ impl<'c> Session<'c> {
         Session {
             cache: cache,
             generic_impls: Default::default(),
+            cargo_roots: Default::default(),
         }
     }
 
@@ -802,6 +806,18 @@ impl<'c> Session<'c> {
         raw.contains_key(path) && masked.contains_key(path)
     }
 
+    /// Find the library root for kratename
+    ///
+    /// The library is searched for by checking
+    ///
+    /// 1. overrides
+    /// 2. lock file
+    /// 3. toml file
+    pub fn get_crate_file(&self, kratename: &str, from_path: &path::Path) -> Option<path::PathBuf> {
+        self.cargo_roots.borrow_mut().entry((kratename.into(), from_path.into()))
+            .or_insert_with(|| cargo::get_crate_file(kratename, from_path))
+            .clone()
+    }
 }
 
 impl<'c> SessionExt for Session<'c> {

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -4,6 +4,8 @@
 #![cfg_attr(feature = "clippy", allow(clippy))]
 #![cfg_attr(all(feature = "clippy", not(test)), deny(print_stdout))]
 
+#![cfg_attr(feature = "nightly", feature(test))]
+
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
 
@@ -33,3 +35,6 @@ pub use core::{FileCache, Session, Coordinate, Location, FileLoader, Point, Sour
 pub use util::expand_ident;
 
 pub use util::{RustSrcPathError, get_rust_src_path};
+
+#[cfg(all(feature = "nightly", test))]
+mod benches;

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -25,22 +25,22 @@ pub fn match_types(src: Src, blobstart: Point, blobend: Point,
                    search_type: SearchType,
                    local: bool, session: &Session,
                    pending_imports: &PendingImports) -> impl Iterator<Item=Match> {
-    let it = match_extern_crate(&src, blobstart, blobend, searchstr, filepath, search_type, session).into_iter();
-    let it = it.chain(match_mod(src, blobstart, blobend, searchstr, filepath, search_type, local, session).into_iter());
-    let it = it.chain(match_struct(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    let it = it.chain(match_type(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    let it = it.chain(match_trait(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    let it = it.chain(match_enum(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    it.chain(match_use(&src, blobstart, blobend, searchstr, filepath, search_type, local, session, pending_imports).into_iter())
+    match_extern_crate(&src, blobstart, blobend, searchstr, filepath, search_type, session).into_iter()
+        .chain(match_mod(src, blobstart, blobend, searchstr, filepath, search_type, local, session))
+        .chain(match_struct(&src, blobstart, blobend, searchstr, filepath, search_type, local))
+        .chain(match_type(&src, blobstart, blobend, searchstr, filepath, search_type, local))
+        .chain(match_trait(&src, blobstart, blobend, searchstr, filepath, search_type, local))
+        .chain(match_enum(&src, blobstart, blobend, searchstr, filepath, search_type, local))
+        .chain(match_use(&src, blobstart, blobend, searchstr, filepath, search_type, local, session, pending_imports))
 }
 
 pub fn match_values(src: Src, blobstart: Point, blobend: Point,
                     searchstr: &str, filepath: &Path, search_type: SearchType,
                     local: bool) -> impl Iterator<Item=Match> {
-    let it = match_const(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter();
-    let it = it.chain(match_static(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    let it = it.chain(match_fn(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    it.chain(match_macro(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter())
+    match_const(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter()
+        .chain(match_static(&src, blobstart, blobend, searchstr, filepath, search_type, local))
+        .chain(match_fn(&src, blobstart, blobend, searchstr, filepath, search_type, local))
+        .chain(match_macro(&src, blobstart, blobend, searchstr, filepath, search_type, local))
 }
 
 fn strip_keyword_prefix(src: &str, keyword: &str) -> Option<Point> {
@@ -427,7 +427,7 @@ pub fn match_struct(msrc: &str, blobstart: Point, blobend: Point,
             local: local,
             mtype: Struct,
             contextstr: get_context(blob, "{"),
-            generic_args: generics.generic_args.into_iter().map(|arg| {arg.name}).collect(),
+            generic_args: generics.generic_args.into_iter().map(|arg| arg.name).collect(),
             generic_types: Vec::new(),
             docs: find_doc(msrc, blobstart + start),
         })
@@ -500,7 +500,7 @@ pub fn match_enum_variants(msrc: &str, blobstart: Point, blobend: Point,
         // parse the enum
         let parsed_enum = ast::parse_enum(blob.to_owned());
 
-        for (name, offset) in parsed_enum.values.into_iter() {
+        for (name, offset) in parsed_enum.values {
             if name.starts_with(searchstr) {
                 let m = Match {
                     matchstr: name,
@@ -544,7 +544,7 @@ pub fn match_enum(msrc: &str, blobstart: Point, blobend: Point,
             local: local,
             mtype: Enum,
             contextstr: first_line(blob),
-            generic_args: generics.generic_args.into_iter().map(|arg| {arg.name}).collect(),
+            generic_args: generics.generic_args.into_iter().map(|arg| arg.name).collect(),
             generic_types: Vec::new(),
             docs: find_doc(msrc, blobstart + start),
         })
@@ -604,7 +604,7 @@ pub fn match_use(msrc: &str, blobstart: Point, blobend: Point,
         let use_item = ast::parse_use(blob.to_owned());
 
         let ident = use_item.ident.unwrap_or("".into());
-        for path in use_item.paths.into_iter() {
+        for path in use_item.paths {
             let len = path.path.segments.len();
             if symbol_matches(search_type, searchstr, &path.ident) { // i.e. 'use foo::bar as searchstr'
                 if len == 1 && path.path.segments[0].name == searchstr {

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -12,11 +12,9 @@ use core::MatchType::{Module, Function, Struct, Enum, EnumVariant, FnArg, Trait,
 use core::Namespace;
 use ast::{GenericsVisitor, ImplVisitor};
 
-
 use util::{self, closure_valid_arg_scope, symbol_matches, txt_matches,
-    find_ident_end, get_rust_src_path};
+           find_ident_end, get_rust_src_path};
 use matchers::find_doc;
-use cargo;
 use matchers::PendingImports;
 
 lazy_static! {
@@ -754,7 +752,7 @@ pub fn search_next_scope(mut startpoint: Point, pathseg: &core::PathSegment,
 
 pub fn get_crate_file(name: &str, from_path: &Path, session: &Session) -> Option<PathBuf> {
     debug!("get_crate_file {}, {:?}", name, from_path);
-    if let Some(p) = cargo::get_crate_file(name, from_path) {
+    if let Some(p) = session.get_crate_file(name, from_path) {
         debug!("get_crate_file  - found the crate file! {:?}", p);
         return Some(p);
     }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -34,7 +34,7 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
 
     let mut out = Vec::new();
 
-    for (field, field_point, ty) in fields.into_iter() {
+    for (field, field_point, ty) in fields {
         if symbol_matches(search_type, searchstr, &field) {
             let contextstr = if let Some(t) = ty {
                 t.to_string()
@@ -850,7 +850,7 @@ pub fn search_scope(start: Point, point: Point, src: Src,
         for m in matchers::match_let(&src, start+blobstart,
                                      start+blobend,
                                      searchstr,
-                                     filepath, search_type, local).into_iter() {
+                                     filepath, search_type, local) {
             out.push(m);
             if let ExactMatch = search_type {
                 return out.into_iter();
@@ -954,7 +954,7 @@ pub fn search_scope(start: Point, point: Point, src: Src,
         // There's a good chance of a match. Run the matchers
         for m in run_matchers_on_blob(src, start+blobstart, start+blobend,
                                       searchstr, filepath, search_type,
-                                      local, namespace, session, pending_imports).into_iter() {
+                                      local, namespace, session, pending_imports) {
             out.push(m);
             if let ExactMatch = search_type {
                 return out.into_iter();

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -225,7 +225,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &Ses
     let structsrc = scopes::end_of_next_scope(&src[opoint..]);
 
     let fields = ast::parse_struct_fields(structsrc.to_owned(), Scope::from_match(structmatch));
-    for (field, _, ty) in fields.into_iter() {
+    for (field, _, ty) in fields {
         if fieldname == field {
             return ty;
         }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -35,15 +35,11 @@ pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
                 return true;
             }
 
-            // PD: switch to use .match_indices() when that stabilizes
-            let mut n=0;
-            while let Some(n1) = haystack[n..].find(needle) {
-                n += n1;
-                if (n == 0  || !is_ident_char(char_at(haystack, n-1))) &&
+            for (n, _) in haystack.match_indices(needle) {
+                if (n == 0 || !is_ident_char(char_before(haystack, n))) &&
                     (n+n_len == h_len || !is_ident_char(char_at(haystack, n+n_len))) {
                     return true;
                 }
-                n += 1;
             }
             false
         },
@@ -52,14 +48,10 @@ pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
                 return true;
             }
 
-            // PD: switch to use .match_indices() when that stabilizes
-            let mut n=0;
-            while let Some(n1) = haystack[n..].find(needle) {
-                n += n1;
-                if n == 0  || !is_ident_char(char_at(haystack, n-1)) {
+            for (n, _) in haystack.match_indices(needle) {
+                if n == 0 || !is_ident_char(char_before(haystack, n)) {
                     return true;
                 }
-                n += 1;
             }
             false
         }
@@ -124,12 +116,14 @@ pub fn closure_valid_arg_scope(scope_src: &str) -> Option<(usize, usize, &str)> 
 
 #[test]
 fn txt_matches_matches_stuff() {
-    assert_eq!(true, txt_matches(ExactMatch, "Vec","Vec"));
-    assert_eq!(true, txt_matches(StartsWith, "Vec","Vector"));
-    assert_eq!(false, txt_matches(ExactMatch, "Vec","use Vector"));
-    assert_eq!(true, txt_matches(StartsWith, "Vec","use Vector"));
-    assert_eq!(false, txt_matches(StartsWith, "Vec","use aVector"));
-    assert_eq!(true, txt_matches(ExactMatch, "Vec","use Vec"));
+    assert_eq!(true, txt_matches(ExactMatch, "Vec", "Vec"));
+    assert_eq!(true, txt_matches(ExactMatch, "Vec", "use Vec"));
+    assert_eq!(false, txt_matches(ExactMatch, "Vec", "use Vecä"));
+
+    assert_eq!(true, txt_matches(StartsWith, "Vec", "Vector"));
+    assert_eq!(true, txt_matches(StartsWith, "Vec", "use Vector"));
+    assert_eq!(true, txt_matches(StartsWith, "Vec", "use Vec"));
+    assert_eq!(false, txt_matches(StartsWith, "Vec", "use äVector"));
 }
 
 #[test]
@@ -253,8 +247,25 @@ fn find_ident_end_unicode() {
     assert_eq!(10, find_ident_end("ends_in_µ", 0));
 }
 
-// PD: short term replacement for .char_at() function. Should be replaced once
-// that stabilizes
+fn char_before(src: &str, i: usize) -> char {
+    let mut prev = '\0';
+    for (ii, ch) in src.char_indices() {
+        if ii >= i {
+            return prev;
+        }
+        prev = ch;
+    }
+    return prev;
+}
+
+#[test]
+fn test_char_before() {
+    assert_eq!('ä', char_before("täst", 3));
+    assert_eq!('ä', char_before("täst", 2));
+    assert_eq!('s', char_before("täst", 4));
+    assert_eq!('t', char_before("täst", 100));
+}
+
 pub fn char_at(src: &str, i: usize) -> char {
     src[i..].chars().next().unwrap()
 }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -1,6 +1,5 @@
 // Small functions of utility
-use std::cmp;
-use std::path;
+use std::{cmp, error, fmt, path};
 use std::rc::Rc;
 
 use core::{IndexedSource, Session, SessionExt, Location, LocationExt, Point};
@@ -170,7 +169,7 @@ pub fn expand_ident<P, C>(
     cursor: C,
     session: &Session
 ) -> Option<ExpandedIdent>
-    where P: AsRef<::std::path::Path>,
+    where P: AsRef<path::Path>,
           C: Into<Location>
 {
     let cursor = cursor.into();
@@ -260,9 +259,7 @@ pub fn char_at(src: &str, i: usize) -> char {
     src[i..].chars().next().unwrap()
 }
 
-/// Error type returned from [`check_rust_src_env_var()`]
-///
-/// [`check_rust_src_env_var()`]: fn.check_rust_src_env_var.html
+/// Error type returned from validate_rust_src_path()
 #[derive(Debug, PartialEq)]
 pub enum RustSrcPathError {
     Missing,
@@ -270,8 +267,8 @@ pub enum RustSrcPathError {
     NotRustSourceTree(path::PathBuf),
 }
 
-impl ::std::error::Error for RustSrcPathError {
-    fn cause(&self) -> Option<&::std::error::Error> {
+impl error::Error for RustSrcPathError {
+    fn cause(&self) -> Option<&error::Error> {
         None
     }
 
@@ -284,8 +281,8 @@ impl ::std::error::Error for RustSrcPathError {
     }
 }
 
-impl ::std::fmt::Display for RustSrcPathError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl fmt::Display for RustSrcPathError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RustSrcPathError::Missing => {
                 write!(f, "RUST_SRC_PATH environment variable must be set to \
@@ -311,7 +308,7 @@ impl ::std::fmt::Display for RustSrcPathError {
 }
 
 fn check_rust_sysroot() -> Option<path::PathBuf> {
-    use ::std::process::Command;
+    use std::process::Command;
     let mut cmd = Command::new("rustc");
     cmd.arg("--print").arg("sysroot");
 
@@ -362,7 +359,7 @@ fn check_rust_sysroot() -> Option<path::PathBuf> {
 ///     }
 /// }
 /// ```
-pub fn get_rust_src_path() -> ::std::result::Result<path::PathBuf, RustSrcPathError> {
+pub fn get_rust_src_path() -> Result<path::PathBuf, RustSrcPathError> {
     use std::env;
 
     debug!("Getting rust source path. Trying env var RUST_SRC_PATH.");
@@ -399,7 +396,7 @@ pub fn get_rust_src_path() -> ::std::result::Result<path::PathBuf, RustSrcPathEr
     return Err(RustSrcPathError::Missing)
 }
 
-fn validate_rust_src_path(path: path::PathBuf) -> ::std::result::Result<path::PathBuf, RustSrcPathError> {
+fn validate_rust_src_path(path: path::PathBuf) -> Result<path::PathBuf, RustSrcPathError> {
     if !path.exists() {
         Err(RustSrcPathError::DoesNotExist(path.to_path_buf()))
     } else if !path.join("libstd").exists() {
@@ -411,7 +408,7 @@ fn validate_rust_src_path(path: path::PathBuf) -> ::std::result::Result<path::Pa
 
 #[cfg(test)]
 lazy_static! {
-    static ref TEST_SEMAPHORE: ::std::sync::Mutex<()> = ::std::sync::Mutex::new(());
+    static ref TEST_SEMAPHORE: ::std::sync::Mutex<()> = Default::default();
 }
 
 #[test]


### PR DESCRIPTION
This reduces the number of toml parsings to 226 for completing "std::".
Before it was over 9000! (insert meme here).

I also made a change to logging so that it is more suitable for checking the timings of individual steps.

PR also includes a few minor things I found on the way - best to review each commit independently.