### PR TITLE
Cache generic impls

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -39,6 +39,7 @@ pub fn with_error_checking_parse<F, T>(s: String, f: F) -> Option<T>
 
 // parse a string, return a stmt
 pub fn string_to_stmt(source_str: String) -> Option<ast::Stmt> {
+    trace!("string_to_stmt: {:?}", source_str);
     with_error_checking_parse(source_str, |p| {
         match p.parse_stmt() {
             Ok(Some(stmt)) => Some(stmt),
@@ -49,6 +50,7 @@ pub fn string_to_stmt(source_str: String) -> Option<ast::Stmt> {
 
 // parse a string, return a crate.
 pub fn string_to_crate(source_str: String) -> Option<ast::Crate> {
+    trace!("string_to_crate: {:?}", source_str);
     with_error_checking_parse(source_str.clone(), |p| {
         use std::result::Result::{Ok, Err};
         match p.parse_crate_mod() {
@@ -1067,6 +1069,16 @@ pub fn parse_generics(s: String) -> GenericsVisitor {
         visit::walk_stmt(&mut v, &stmt);
     }
     v
+}
+
+pub fn parse_generics_and_impl(s: String) -> (GenericsVisitor, ImplVisitor) {
+    let mut v = GenericsVisitor { generic_args: Vec::new() };
+    let mut w = ImplVisitor { name_path: None, trait_path: None };
+    if let Some(stmt) = string_to_stmt(s) {
+        visit::walk_stmt(&mut v, &stmt);
+        visit::walk_stmt(&mut w, &stmt);
+    }
+    (v, w)
 }
 
 pub fn parse_type(s: String) -> TypeVisitor {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -738,6 +738,10 @@ pub struct Session<'c> {
     /// The file cache is used within a session to prevent multiple reads. It is
     /// borrowed here in order to support reuse across Racer operations.
     cache: &'c FileCache,
+    /// Cache for generic impls
+    pub generic_impls: RefCell<HashMap<(path::PathBuf, usize),
+                                       Rc<Vec<(usize, String,
+                                               ast::GenericsVisitor, ast::ImplVisitor)>>>>,
 }
 
 impl<'c> fmt::Debug for Session<'c> {
@@ -764,7 +768,8 @@ impl<'c> Session<'c> {
     /// [`FileCache`]: struct.FileCache.html
     pub fn new(cache: &'c FileCache) -> Session<'c> {
         Session {
-            cache: cache
+            cache: cache,
+            generic_impls: Default::default(),
         }
     }
 

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -340,8 +340,7 @@ pub fn search_for_generic_impls(pos: Point, searchstr: &str, contextm: &Match, f
                 }
                 let mut decl = decl.to_owned();
                 decl.push_str("}");
-                let generics = ast::parse_generics(decl.clone());
-                let implres = ast::parse_impl(decl.clone());
+                let (generics, implres) = ast::parse_generics_and_impl(decl.clone());
                 if let (Some(name_path), Some(trait_path)) = (implres.name_path, implres.trait_path) {
                     if let (Some(name), Some(trait_name)) = (name_path.segments.last(), trait_path.segments.last()) {
                         for gen_arg in generics.generic_args {

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -54,6 +54,7 @@ impl MethodInfo {
         let trim: &[_] = &['\n', '\r', '{', ' '];
         let decorated = format!("{} {{}}()", source.trim_right_matches(trim));
 
+        trace!("MethodInfo::from_source_str: {:?}", decorated);
         with_error_checking_parse(decorated, |p| {
             if let Ok(method) = p.parse_impl_item() {
                 if let ImplItemKind::Method(ref msig, _) = method.node {


### PR DESCRIPTION
This speeds up generics search by parsing the code only once, and adds a cache for generic impls, since this is something that's repeated quite often.

For me, this saves about 160ms when completing the members of a HashMap.