### PR TITLE
Remove pc-windows-gnu from appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,16 +23,14 @@ environment:
     #   CHANNEL: beta
 
     # Nightly channel
-    - TARGET: i686-pc-windows-gnu
-      CHANNEL: nightly
+    # - TARGET: i686-pc-windows-gnu
+    #   CHANNEL: nightly
     - TARGET: i686-pc-windows-msvc
       CHANNEL: nightly
-    # Commented out because AppVeyor builds jobs serially
-    # so building all targets would be very slow.
     # - TARGET: x86_64-pc-windows-gnu
     #   CHANNEL: nightly
-    # - TARGET: x86_64-pc-windows-msvc
-    #   CHANNEL: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: nightly
 
 # Install Rust and Cargo
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)


### PR DESCRIPTION
It's for #855 
To compile `cargo`, we have to build some C libraries and we got the error `is `make` not installed?` first.
So I add `C:\msys64\usr\bin` but then got 10000 lines of error that 
```
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
```
(see https://ci.appveyor.com/project/kngwyu/racer-nightly/build/1.0.8)

So, I gave up.
And I also want to note that `cargo` and other related crates like `ssh2-rs` also don't use pc-windows-gnu target in appveyor.