### PR TITLE
Readme update: RUST_SRC_PATH not mandatory anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,14 @@ As mentioned in the command output, don't forget to add the installation directo
 
     2. manually from git, or download from https://www.rust-lang.org/install.html (the 'rustc' source download behind the 'source' link is the right one).
 
-2. Set the ```RUST_SRC_PATH``` environment variable to point to the 'src' dir in the Rust source installation
+    Ensure to download sources for any rust version you have installed (e.g. a common configuration is to have the `stable` and many `nightly` installed).
+
+2. (OPTIONAL) Set the ```RUST_SRC_PATH``` environment variable to point to the 'src' dir in the Rust source installation
 
    (e.g. ```% export RUST_SRC_PATH=/usr/local/src/rust/src``` or ```% export RUST_SRC_PATH="$(rustc --print sysroot)/lib/rustlib/src/rust/src"``` )
-   
+
+   This is not mandatory anymore to use `racer`.
+
 3. Test on the command line:
 
    ```racer complete std::io::B ```  (should show some completions)

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Vim integration has been moved to a separate project: [vim-racer](https://github
 
 Racer recommends the [`vscode-rust` extension](https://github.com/editor-rs/vscode-rust). This is an actively-maintained fork of the now-deprecated [`RustyCode` extension](https://github.com/saviorisdead/RustyCode).
 
-### Atom integration 
+### Atom integration
 
 You can find the racer package for Atom [here](https://atom.io/packages/autocomplete-racer)
 
-### Kakoune integration 
+### Kakoune integration
 
 [Kakoune](https://github.com/mawww/kakoune) comes with a builtin integration for racer auto completion.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,21 @@ As mentioned in the command output, don't forget to add the installation directo
 
     1. automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `$(rustc --print sysroot)/lib/rustlib/src/rust/src`. Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
 
-    2. manually from git, or download from https://www.rust-lang.org/install.html (the 'rustc' source download behind the 'source' link is the right one).
+    2. manually from git: https://github.com/rust-lang/rust
 
-    Ensure to download sources for any rust version you have installed (e.g. a common configuration is to have the `stable` and many `nightly` installed).
+    *Note*
 
-2. (OPTIONAL) Set the ```RUST_SRC_PATH``` environment variable to point to the 'src' dir in the Rust source installation
+     If you want to use `racer` with multiple release channels (Rust has 3 release channels: `stable`, `beta` and `nightly`), you have to also download Rust source code for each release channel you install.
+
+    e.g. (rustup case) Add a nightly toolchain build and install nightly sources too
+
+    `rustup toolchain add nightly`
+
+    `rustup component add rust-src`
+
+2. (Only needed if downloaded the sources) Set the ```RUST_SRC_PATH``` environment variable to point to the 'src' dir in the Rust source installation
 
    (e.g. ```% export RUST_SRC_PATH=/usr/local/src/rust/src``` or ```% export RUST_SRC_PATH="$(rustc --print sysroot)/lib/rustlib/src/rust/src"``` )
-
-   This is not mandatory anymore to use `racer`.
 
 3. Test on the command line:
 


### PR DESCRIPTION
Hello,

as briefly discussed [here](https://github.com/racer-rust/emacs-racer/issues/93#issuecomment-393747999) the env var `RUST_SRC_PATH` is to not mandatory anymore.

If this env var is actually not really needed, could it be useful to relax the configuration requirements for `racer`? Possibly this may lead to a couple of `racer` issue disappearing (not really sure about this, haven't investigated really closely).

And how about removing mentioning this env var altogether to simplify the config process?

Feel free to suggest on how to improve this little doc update or OTOH is not really needed and can be yanked.

Thanks!