### PR TITLE
Enable completion for closure args

### DIFF
--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -103,8 +103,9 @@ impl<'a,I> Iterator for StmtIndicesIter<'a,I>
                     }
                     _ => {}
                 }
-
-                if enddelim == b && bracelevel == 0 && parenlevel == 0 && bracketlevel == 0 {
+                if parenlevel < 0 || bracelevel < 0 || bracketlevel < 0
+                    || (enddelim == b && bracelevel == 0 && parenlevel == 0 && bracketlevel == 0)
+                {
                     self.pos = pos;
                     return Some((start, pos));
                 }

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -65,8 +65,14 @@ pub fn scope_start(src: Src, point: Point) -> Point {
 }
 
 pub fn find_stmt_start(msrc: Src, point: Point) -> Option<Point> {
-    // Iterate the scope to find the start of the statement that surrounds the point.
     let scopestart = scope_start(msrc, point);
+    // Iterate the scope to find the start of the statement that surrounds the point.
+    debug!(
+        "[find_stmt_start] now we are in scope {} ~ {}, {}",
+        scopestart,
+        point,
+        &msrc[scopestart..point + 1]
+    );
     msrc.from(scopestart).iter_stmts()
         .find(|&(start, end)| scopestart + start < point && point < scopestart + end)
         .map(|(start, _)| scopestart + start)
@@ -74,7 +80,7 @@ pub fn find_stmt_start(msrc: Src, point: Point) -> Option<Point> {
 
 /// Finds a statement start or panics.
 pub fn expect_stmt_start(msrc: Src, point: Point) -> Point {
-    find_stmt_start(msrc, point).expect("Statement has a beginning")
+    find_stmt_start(msrc, point).expect("Statement does not have a beginning")
 }
 
 /// Finds the start of a `let` statement; includes handling of struct pattern matches in the

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -122,25 +122,63 @@ pub fn get_type_of_self(point: Point, filepath: &Path, local: bool, msrc: Src, s
     })
 }
 
+fn is_closure(src: &str) -> Option<bool> {
+    let s = src.matches(|c| c == '{' || c == '|').nth(0)?;
+    Some(s == "|")
+}
+
+fn find_start_of_closure_body(src: &str) -> Option<Point> {
+    let mut cnt = 0;
+    for (i, c) in src.chars().enumerate() {
+        if c == '|' {
+            cnt += 1;
+        }
+        if cnt == 2 {
+            return Some(i + 1);
+        }
+    }
+    warn!(
+        "[find_start_of_closure_body] start of closure body not found!: {}",
+        src
+    );
+    None
+}
+
 fn get_type_of_fnarg(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
     if m.matchstr == "self" {
         return get_type_of_self_arg(m, msrc, session);
     }
 
-    let stmtstart = scopes::expect_stmt_start(msrc, m.point);
+    let stmtstart = match scopes::find_stmt_start(msrc, m.point) {
+        Some(s) => s,
+        None => {
+            warn!(
+                "[get_type_of_fnarg] start of statement was not found for {:?}",
+                m
+            );
+            return None;
+        }
+    };
     let block = msrc.from(stmtstart);
-    if let Some((start, end)) = block.iter_stmts().next() {
-        let blob = &msrc[(stmtstart+start)..(stmtstart+end)];
+    let (start, end) = block.iter_stmts().nth(0)?;
+    let blob = &msrc[(stmtstart + start)..(stmtstart + end)];
+    let is_closure = is_closure(blob)?;
+    if is_closure {
+        let start_of_body = find_start_of_closure_body(blob)?;
+        let s = format!("{}{{}}", &blob[..start_of_body]);
+        let argpos = m.point - (stmtstart + start);
+        ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session)
+    } else {
         // wrap in "impl blah { }" so that methods get parsed correctly too
-        let mut s = String::new();
-        s.push_str("impl blah {");
-        let impl_header_len = s.len();
-        s.push_str(&blob[..(find_start_of_function_body(blob)+1)]);
-        s.push_str("}}");
-        let argpos = m.point - (stmtstart+start) + impl_header_len;
-        return ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session);
+        let start_blah = "impl blah {";
+        let s = format!(
+            "{}{}}}}}",
+            start_blah,
+            &blob[..(find_start_of_function_body(blob) + 1)]
+        );
+        let argpos = m.point - (stmtstart + start) + start_blah.len();
+        ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session)
     }
-    None
 }
 
 fn get_type_of_let_expr(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3888,6 +3888,21 @@ fn completes_methods_for_closure_arg() {
             .into_iter()
             .any(|ma| ma.matchstr == "append")
     );
+    let src = r"
+        fn main() {
+            let mut v = Vec::new();
+            v.push(3);
+            let s = Some(v);
+            let x = s.map(|v: Vec<i32>| {
+                v.appen~
+            });
+        }
+    ";
+    assert!(
+        get_all_completions(src, None)
+            .into_iter()
+            .any(|ma| ma.matchstr == "append")
+    );
 }
 
 // for #856

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3780,7 +3780,6 @@ fn follows_use_aliased_self() {
     assert_eq!(got.matchstr, "new");
 }
 
-
 // test for re-export
 #[test]
 fn follows_use_for_reexport() {
@@ -3872,4 +3871,36 @@ fn main() {
 "#;
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "EnumB");
+}
+
+#[test]
+fn completes_methods_for_closure_arg() {
+    let src = r"
+        fn main() {
+            let mut v = Vec::new();
+            v.push(3);
+            let s = Some(v);
+            let x = s.map(|v: Vec<i32>| v.appen~);
+        }
+    ";
+    assert!(
+        get_all_completions(src, None)
+            .into_iter()
+            .any(|ma| ma.matchstr == "append")
+    );
+}
+
+// for #856
+#[test]
+fn finds_method_definition_in_1line_closure() {
+    let src = r"
+        fn main() {
+            let mut v = Vec::new();
+            v.push(3);
+            let s = Some(v);
+            let x = s.map(|v: Vec<i32>| v.pus~h(2));
+        }
+    ";
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "push");
 }


### PR DESCRIPTION
Only when type annotation given.

And also solves #856.
For one-line closure, we call `find_stmt_start` to `|v: Vec<i32>| ... )` so parentheses do not always correspond. I modified `StmtIndicesIter::next` for such a case.