### PR TITLE
Move tests/utils.rs into testutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.py[cod]
 .vscode/**
 test_project/**/Cargo.lock
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,15 @@ dependencies = [
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "racer-testutils 0.1.0",
  "rustc-ap-syntax 151.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "racer-testutils"
+version = "0.1.0"
+dependencies = [
+ "racer 2.0.14",
  "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,11 @@ lazy_static = "1.0"
 humantime = "1.1"
 
 [dev-dependencies]
-tempfile = "3.0"
+racer-testutils = { path = "testutils" }
 
 [features]
 nightly = []
 clippy = []
+
+[workspace]
+members = ["testutils"]

--- a/benches/bench_globs.rs
+++ b/benches/bench_globs.rs
@@ -1,0 +1,65 @@
+//! for #844
+#![feature(test)]
+extern crate racer_testutils;
+extern crate test;
+use test::Bencher;
+
+use racer_testutils::*;
+
+#[bench]
+fn glob_imports5(b: &mut Bencher) {
+    let src = r"
+use a::*;
+use b::*;
+use c::*;
+use d::*;
+use e::*;
+pub fn foo() -> () {
+    Whatever::~
+}
+";
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}
+
+#[bench]
+fn glob_imports6(b: &mut Bencher) {
+    let src = r"
+use a::*;
+use b::*;
+use c::*;
+use d::*;
+use e::*;
+use f::*;
+pub fn foo() -> () {
+    Whatever::~
+}
+";
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}
+
+#[bench]
+fn glob_imports7(b: &mut Bencher) {
+    let src = r"
+use a::*;
+use b::*;
+use c::*;
+use d::*;
+use e::*;
+use f::*;
+use g::*;
+pub fn foo() -> () {
+    Whatever::~
+}
+";
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}
+

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1,11 +1,10 @@
 extern crate racer;
-extern crate tempfile;
-mod utils;
+extern crate racer_testutils;
+
 use racer::{complete_from_file, Coordinate, MatchType};
 use std::path::Path;
 
-use utils::*;
-
+use racer_testutils::*;
 
 #[test]
 fn completes_fn() {

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+publish = false
+workspace = ".."
+name = "racer-testutils"
+version = "0.1.0"
+authors = ["Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>"]
+
+[dependencies]
+racer = { path = "../" }
+tempfile = "3.0"

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -135,7 +135,7 @@ impl fmt::Debug for TmpDir {
 /// copy test_project/* into TempDir
 fn setup_test_project() -> TmpDir {
     let tmp_dir = TmpDir::new();
-    let test_project = Path::new(env!("CARGO_MANIFEST_DIR")).join("test_project");
+    let test_project = Path::new(env!("CARGO_MANIFEST_DIR")).join("../test_project");
     // copy test project to temp dir recursively
     fn copy_dirs(abs_path: &Path, tmp_path: &Path) -> io::Result<()> {
         if !abs_path.is_dir() {


### PR DESCRIPTION
To use common utility code from both of tests and benches.
And add benchmark for #844, here is the result.
```
test glob_imports5 ... bench:  53,956,377 ns/iter (+/- 2,045,050)
test glob_imports6 ... bench: 307,321,133 ns/iter (+/- 34,592,106)
test glob_imports7 ... bench: 2,046,519,408 ns/iter (+/- 161,600,731)
```
So, sadly, if we have 7 glob imports in code we have to wait 20 seconds!