### PR TITLE
Use newtypes for representing code position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +681,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -689,6 +707,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -701,11 +727,13 @@ version = "2.0.14"
 dependencies = [
  "cargo 0.29.0 (git+https://github.com/rust-lang/cargo?rev=d775dddd31ce56a78e2f368f546311bfd94135b6)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer-testutils 0.1.0",
+ "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-ap-syntax 151.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -767,6 +795,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rls-span"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-arena"
@@ -893,6 +926,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1045,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1241,6 +1292,7 @@ dependencies = [
 "checksum crypto-hash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "09de9ee0fc255ace04c7fa0763c9395a945c37c8292bb554f8d48361d1dcf1b4"
 "checksum curl 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf20bbe084f285f215eef2165feed70d6b75ba29cad24469badb853a4a287d0"
 "checksum curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71c63a540a9ee4e15e56c3ed9b11a2f121239b9f6d7b7fe30f616e048148df9a"
+"checksum derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46c7f14685a20f5dd08e7f754f2ea8cc064d8f4214ae21116c106a2768ba7b9b"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88dc8393b3c7352f94092497f6b52019643e493b6b890eb417cdb7c46117e621"
@@ -1290,9 +1342,11 @@ dependencies = [
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e53eeda07ddbd8b057dde66d9beded11d0dfda13f0db0769e6b71d6bcf2074e"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
@@ -1300,6 +1354,7 @@ dependencies = [
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rustc-ap-arena 151.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "746ee5f3cf21c39b18ffd086a89d5b1c3b1e955c3e4bbd2b079b36c48ad68d46"
 "checksum rustc-ap-rustc_cratesio_shim 151.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "827fb629eb8e598bac61759eed857400d6ac9c9db448a4e9adb13d5d59509eb3"
 "checksum rustc-ap-rustc_data_structures 151.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d8890aef70f20c039b04238f5e43c087df94020948c5ef860687ce07468a762b"
@@ -1312,6 +1367,7 @@ dependencies = [
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1aa5cd8c3a706edb19b6ec6aa7b056bdc635b6e99c5cf7014f9af9d92f15e99"
 "checksum rustc-rayon-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d69983f8613a9c3ba1a3bbf5e8bdf2fd5c42317b1d8dd8623ca8030173bf8a6b"
+"checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -1328,6 +1384,7 @@ dependencies = [
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d991a9e7c33123925e511baab68f7ec25c3795962fe326a2395e5a42a614f0"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ env_logger = "0.5"
 clap = "2.19"
 lazy_static = "1.0"
 humantime = "1.1"
+derive_more = "0.11.0"
+rls-span = "0.4.0"
 
 [dev-dependencies]
 racer-testutils = { path = "testutils" }

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1,4 +1,4 @@
-use core::{self, Match, MatchType, Scope, Ty, Session, SessionExt, Point, SourceByteRange};
+use core::{self, Match, MatchType, Scope, Ty, Session, SessionExt, BytePos, ByteRange};
 use typeinf;
 use nameres::{self, resolve_path_with_str};
 use scopes;
@@ -57,7 +57,7 @@ where
     }).is_some()
 }
 
-fn destruct_span(span: Span) -> (u32, u32) {
+pub(crate) fn destruct_span(span: Span) -> (u32, u32) {
     let codemap::BytePos(lo) = span.lo();
     let codemap::BytePos(hi) = span.hi();
     (lo, hi)
@@ -162,7 +162,7 @@ impl<'ast> visit::Visitor<'ast> for UseVisitor {
 }
 
 pub struct PatBindVisitor {
-    ident_points: Vec<SourceByteRange>
+    ident_points: Vec<ByteRange>
 }
 
 impl<'ast> visit::Visitor<'ast> for PatBindVisitor {
@@ -185,8 +185,7 @@ impl<'ast> visit::Visitor<'ast> for PatBindVisitor {
     fn visit_pat(&mut self, p: &ast::Pat) {
         match p.node {
             PatKind::Ident(_ , ref spannedident, _) => {
-                let (lo, hi) = destruct_span(spannedident.span);
-                self.ident_points.push((lo as usize, hi as usize));
+                self.ident_points.push(spannedident.span.into());
             }
             _ => {
                 visit::walk_pat(self, p);
@@ -196,15 +195,14 @@ impl<'ast> visit::Visitor<'ast> for PatBindVisitor {
 }
 
 pub struct PatVisitor {
-    ident_points: Vec<SourceByteRange>
+    ident_points: Vec<ByteRange>
 }
 
 impl<'ast> visit::Visitor<'ast> for PatVisitor {
     fn visit_pat(&mut self, p: &ast::Pat) {
         match p.node {
             PatKind::Ident(_ , ref spannedident, _) => {
-                let (lo, hi) = destruct_span(spannedident.span);
-                self.ident_points.push((lo as usize, hi as usize));
+                self.ident_points.push(spannedident.span.into());
             }
             _ => { visit::walk_pat(self, p); }
         }
@@ -247,25 +245,26 @@ fn to_racer_ty(ty: &ast::Ty, scope: &Scope) -> Option<Ty> {
     }
 }
 
-fn point_is_in_span(point: u32, span: &Span) -> bool {
+fn point_is_in_span(point: BytePos, span: &Span) -> bool {
+    let point: u32 = point.0 as u32;
     let (lo, hi) = destruct_span(*span);
     point >= lo && point < hi
 }
 
 // The point must point to an ident within the pattern.
 fn destructure_pattern_to_ty(pat: &ast::Pat,
-                             point: Point,
+                             point: BytePos,
                              ty: &Ty,
                              scope: &Scope,
                              session: &Session) -> Option<Ty> {
-    debug!("destructure_pattern_to_ty point {} ty {:?}    ||||||||    pat: {:?}", point, ty, pat);
+    debug!("destructure_pattern_to_ty point {:?} ty {:?}    ||||||||    pat: {:?}", point, ty, pat);
     match pat.node {
         PatKind::Ident(_ , ref spannedident, _) => {
-            if point_is_in_span(point as u32, &spannedident.span) {
+            if point_is_in_span(point, &spannedident.span) {
                 debug!("destructure_pattern_to_ty matched an ident!");
                 Some(ty.clone())
             } else {
-                panic!("Expecting the point to be in the patident span. pt: {}", point);
+                panic!("Expecting the point to be in the patident span. pt: {:?}", point);
             }
         }
         PatKind::Tuple(ref tuple_elements, _) => {
@@ -273,7 +272,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
                 Ty::Tuple(ref typeelems) => {
                     let mut res = None;
                     for (i, p) in tuple_elements.iter().enumerate() {
-                        if point_is_in_span(point as u32, &p.span) {
+                        if point_is_in_span(point, &p.span) {
                             let ty = &typeelems[i];
                             res = destructure_pattern_to_ty(p, point, ty, scope, session);
                             break;
@@ -292,7 +291,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
                 let mut res = None;
 
                 for (i, p) in children.iter().enumerate() {
-                    if point_is_in_span(point as u32, &p.span) {
+                    if point_is_in_span(point, &p.span) {
 
                         res = typeinf::get_tuplestruct_field_type(i, &m, session)
                             .and_then(|ty|
@@ -319,7 +318,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
                 let mut res = None;
 
                 for child in children {
-                    if point_is_in_span(point as u32, &child.span) {
+                    if point_is_in_span(point, &child.span) {
                         res = typeinf::get_struct_field_type(&child.node.ident.name.as_str(), &m, session)
                             .and_then(|ty|
                                 if let Some(Ty::Match(ref contextmatch)) = contextty {
@@ -349,7 +348,7 @@ struct LetTypeVisitor<'c: 's, 's> {
     scope: Scope,
     session: &'s Session<'c>,
     srctxt: String,
-    pos: Point,        // pos is relative to the srctxt, scope is global
+    pos: BytePos,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
@@ -402,7 +401,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for LetTypeVisitor<'c, 's> {
             });
         }
 
-        debug!("LetTypeVisitor: ty is {:?}. pos is {}, src is |{}|", ty, self.pos, self.srctxt);
+        debug!("LetTypeVisitor: ty is {:?}. pos is {:?}, src is |{}|", ty, self.pos, self.srctxt);
         self.result = ty.and_then(|ty|
            destructure_pattern_to_ty(&local.pat, self.pos, &ty, &self.scope, self.session))
             .and_then(|ty| path_to_match(ty, self.session));
@@ -412,7 +411,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for LetTypeVisitor<'c, 's> {
 struct MatchTypeVisitor<'c: 's, 's> {
     scope: Scope,
     session: &'s Session<'c>,
-    pos: Point,        // pos is relative to the srctxt, scope is global
+    pos: BytePos,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
@@ -429,7 +428,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for MatchTypeVisitor<'c, 's> {
 
             for arm in arms {
                 for pattern in &arm.pats {
-                    if point_is_in_span(self.pos as u32, &pattern.span) {
+                    if point_is_in_span(self.pos, &pattern.span) {
                         debug!("PHIL point is in pattern |{:?}|", pattern);
                         self.result = v.result.as_ref().and_then(|ty|
                                destructure_pattern_to_ty(pattern, self.pos, ty, &self.scope, self.session))
@@ -441,7 +440,12 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for MatchTypeVisitor<'c, 's> {
     }
 }
 
-fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: Point, session: &Session) -> Option<Match> {
+fn resolve_ast_path(
+    path: &ast::Path,
+    filepath: &Path,
+    pos: BytePos,
+    session: &Session
+) -> Option<Match> {
     debug!("resolve_ast_path {:?}", to_racer_path(path));
     nameres::resolve_path_with_str(&to_racer_path(path), filepath, pos, core::SearchType::ExactMatch,
                                    core::Namespace::Both, session).nth(0)
@@ -492,7 +496,7 @@ fn path_to_match(ty: Ty, session: &Session) -> Option<Ty> {
     }
 }
 
-fn find_type_match(path: &core::Path, fpath: &Path, pos: Point, session: &Session) -> Option<Ty> {
+fn find_type_match(path: &core::Path, fpath: &Path, pos: BytePos, session: &Session) -> Option<Ty> {
     debug!("find_type_match {:?}, {:?}", path, fpath);
     let res = resolve_path_with_str(path, fpath, pos, core::SearchType::ExactMatch,
                core::Namespace::Type, session).nth(0).and_then(|m| {
@@ -519,11 +523,11 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: Point, session: &Sessio
 fn get_type_of_typedef(m: &Match, session: &Session, fpath: &Path) -> Option<Match> {
     debug!("get_type_of_typedef match is {:?}", m);
     let msrc = session.load_file_and_mask_comments(&m.filepath);
-    let blobstart = m.point - 5;  // - 5 because 'type '
+    let blobstart = m.point - 5.into();  // - 5 because 'type '
     let blob = msrc.from(blobstart);
 
-    blob.iter_stmts().nth(0).and_then(|(start, end)| {
-        let blob = msrc[blobstart + start..blobstart+end].to_owned();
+    blob.iter_stmts().nth(0).and_then(|range| {
+        let blob = msrc[range.shift(blobstart).to_range()].to_owned();
         debug!("get_type_of_typedef blob string {}", blob);
         let res = parse_type(blob);
         debug!("get_type_of_typedef parsed type {:?}", res.type_);
@@ -533,8 +537,8 @@ fn get_type_of_typedef(m: &Match, session: &Session, fpath: &Path) -> Option<Mat
         let scope_start = scopes::scope_start(src.as_src(), m.point);
 
         // Type of TypeDef cannot be inside the impl block so look outside
-        let outer_scope_start = scope_start.checked_sub(1)
-            .map(|sub| scopes::scope_start(src.as_src(), sub))
+        let outer_scope_start = scope_start.0.checked_sub(1)
+            .map(|sub| scopes::scope_start(src.as_src(), sub.into()))
             .and_then(|s| {
                 let blob = src.from(s);
                 let blob = blob.trim_left();
@@ -574,7 +578,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                 let codemap::BytePos(lo) = path.span.lo();
                 self.result = resolve_ast_path(path,
                                  &self.scope.filepath,
-                                 self.scope.point + lo as usize,
+                                 self.scope.point + lo.into(),
                                  self.session).and_then(|m| {
                                      let msrc = self.session.load_file_and_mask_comments(&m.filepath);
                                      typeinf::get_type_of_match(m, msrc.as_src(), self.session)
@@ -826,7 +830,7 @@ fn path_to_match_including_generics(ty: Ty, contextm: &Match, session: &Session)
 
 fn find_type_match_including_generics(fieldtype: &core::Ty,
                                       filepath: &Path,
-                                      pos: Point,
+                                      pos: BytePos,
                                       structm: &Match,
                                       session: &Session) -> Option<Ty>{
     assert_eq!(&structm.filepath, filepath);
@@ -867,7 +871,7 @@ fn find_type_match_including_generics(fieldtype: &core::Ty,
 
 struct StructVisitor {
     pub scope: Scope,
-    pub fields: Vec<(String, Point, Option<core::Ty>)>
+    pub fields: Vec<(String, BytePos, Option<core::Ty>)>
 }
 
 impl<'ast> visit::Visitor<'ast> for StructVisitor {
@@ -887,7 +891,7 @@ impl<'ast> visit::Visitor<'ast> for StructVisitor {
                 None => format!("{}", self.fields.len()),
             };
 
-            self.fields.push((name, point as usize, ty));
+            self.fields.push((name, point.into(), ty));
         }
     }
 }
@@ -1051,7 +1055,7 @@ impl TraitBounds {
                     let path_search = core::PathSearch {
                         path: path,
                         filepath: filepath.as_ref().to_path_buf(),
-                        point: (point as i32 + offset) as Point,
+                        point: BytePos::from((point as i32 + offset) as u32),
                     };
                     Some(path_search)
                 } else {
@@ -1071,7 +1075,7 @@ pub struct TypeParameter {
     /// the name of type parameter declared in generics, like 'T'
     pub name: String,
     /// The point 'T' appears
-    pub point: usize,
+    pub point: BytePos,
     /// bounds
     pub bounds: TraitBounds,
 }
@@ -1129,7 +1133,7 @@ impl GenericsArgs {
                             TraitBounds::from_ty_param_bounds(&ty_param.bounds, &filepath, offset);
                         Some(TypeParameter {
                             name: param_name,
-                            point: (point as i32 + offset) as Point,
+                            point: BytePos::from((point as i32 + offset) as u32),
                             bounds,
                         })
                     }
@@ -1161,7 +1165,7 @@ impl<'ast, P: AsRef<Path>> visit::Visitor<'ast> for GenericsVisitor<P> {
 
 pub struct EnumVisitor {
     pub name: String,
-    pub values: Vec<(String, Point)>
+    pub values: Vec<(String, BytePos)>
 }
 
 impl<'ast> visit::Visitor<'ast> for EnumVisitor {
@@ -1176,7 +1180,7 @@ impl<'ast> visit::Visitor<'ast> for EnumVisitor {
 
             for variant in &enum_definition.variants {
                 let codemap::BytePos(point) = variant.span.lo();
-                self.values.push((variant.node.ident.to_string(), point as usize));
+                self.values.push((variant.node.ident.to_string(), point.into()));
             }
         }
     }
@@ -1193,13 +1197,13 @@ pub fn parse_use(s: String) -> UseVisitor {
     v
 }
 
-pub fn parse_pat_bind_stmt(s: String) -> Vec<SourceByteRange> {
+pub fn parse_pat_bind_stmt(s: String) -> Vec<ByteRange> {
     let mut v = PatBindVisitor { ident_points: Vec::new() };
     with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
     v.ident_points
 }
 
-pub fn parse_struct_fields(s: String, scope: Scope) -> Vec<(String, Point, Option<core::Ty>)> {
+pub fn parse_struct_fields(s: String, scope: Scope) -> Vec<(String, BytePos, Option<core::Ty>)> {
     let mut v = StructVisitor { scope, fields: Vec::new() };
     with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
     v.fields
@@ -1263,11 +1267,11 @@ pub fn parse_type(s: String) -> TypeVisitor {
     v
 }
 
-pub fn parse_fn_args(s: String) -> Vec<SourceByteRange> {
+pub fn parse_fn_args(s: String) -> Vec<ByteRange> {
     parse_pat_idents(s)
 }
 
-pub fn parse_pat_idents(s: String) -> Vec<SourceByteRange> {
+pub fn parse_pat_idents(s: String) -> Vec<ByteRange> {
     let mut v = PatVisitor{ ident_points: Vec::new() };
     with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
     debug!("ident points are {:?}", v.ident_points);
@@ -1283,12 +1287,12 @@ pub fn parse_fn_output(s: String, scope: Scope) -> Option<core::Ty> {
 
 pub fn parse_fn_arg_type(
     s: String,
-    argpos: Point,
+    argpos: BytePos,
     scope: Scope,
     session: &Session,
     offset: i32,
 ) -> Option<core::Ty> {
-    debug!("parse_fn_arg {} |{}|", argpos, s);
+    debug!("parse_fn_arg {:?} |{}|", argpos, s);
     let mut v = FnArgTypeVisitor {
         argpos,
         scope,
@@ -1319,7 +1323,7 @@ pub fn parse_enum(s: String) -> EnumVisitor {
     v
 }
 
-pub fn get_type_of(s: String, fpath: &Path, pos: Point, session: &Session) -> Option<Ty> {
+pub fn get_type_of(s: String, fpath: &Path, pos: BytePos, session: &Session) -> Option<Ty> {
     let startscope = Scope {
         filepath: fpath.to_path_buf(),
         point: pos
@@ -1332,7 +1336,7 @@ pub fn get_type_of(s: String, fpath: &Path, pos: Point, session: &Session) -> Op
 }
 
 // pos points to an ident in the lhs of the stmtstr
-pub fn get_let_type(s: String, pos: Point, scope: Scope, session: &Session) -> Option<Ty> {
+pub fn get_let_type(s: String, pos: BytePos, scope: Scope, session: &Session) -> Option<Ty> {
     let mut v = LetTypeVisitor {
         scope,
         session,
@@ -1344,7 +1348,7 @@ pub fn get_let_type(s: String, pos: Point, scope: Scope, session: &Session) -> O
     v.result
 }
 
-pub fn get_match_arm_type(s: String, pos: Point, scope: Scope, session: &Session) -> Option<Ty> {
+pub fn get_match_arm_type(s: String, pos: BytePos, scope: Scope, session: &Session) -> Option<Ty> {
     let mut v = MatchTypeVisitor {
         scope,
         session,
@@ -1373,7 +1377,7 @@ impl<'ast> visit::Visitor<'ast> for FnOutputVisitor {
 /// Visitor to detect type of fnarg
 pub struct FnArgTypeVisitor<'c: 's, 's> {
     /// the code point arg appears in search string
-    argpos: Point,
+    argpos: BytePos,
     scope: Scope,
     session: &'s Session<'c>,
     generics: GenericsArgs,
@@ -1400,7 +1404,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for FnArgTypeVisitor<'c, 's> {
         let filepath = &self.scope.filepath;
         self.result = fd.inputs
             .iter()
-            .find(|arg| point_is_in_span(self.argpos as u32, &arg.pat.span))
+            .find(|arg| point_is_in_span(self.argpos, &arg.pat.span))
             .and_then(|arg| {
                 debug!("[FnArgTypeVisitor::visit_fn] type {:?} was found", arg.ty);
                 let ty = to_racer_ty(&arg.ty, &self.scope)

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -523,8 +523,8 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: BytePos, session: &Sess
 fn get_type_of_typedef(m: &Match, session: &Session, fpath: &Path) -> Option<Match> {
     debug!("get_type_of_typedef match is {:?}", m);
     let msrc = session.load_file_and_mask_comments(&m.filepath);
-    let blobstart = m.point - 5.into();  // - 5 because 'type '
-    let blob = msrc.from(blobstart);
+    let blobstart = m.point - BytePos(5);  // 5 == "type ".len()
+    let blob = msrc.get_src_from_start(blobstart);
 
     blob.iter_stmts().nth(0).and_then(|range| {
         let blob = msrc[range.shift(blobstart).to_range()].to_owned();
@@ -540,7 +540,7 @@ fn get_type_of_typedef(m: &Match, session: &Session, fpath: &Path) -> Option<Mat
         let outer_scope_start = scope_start.0.checked_sub(1)
             .map(|sub| scopes::scope_start(src.as_src(), sub.into()))
             .and_then(|s| {
-                let blob = src.from(s);
+                let blob = src.get_src_from_start(s);
                 let blob = blob.trim_left();
                 if blob.starts_with("impl") || blob.starts_with("trait") || blob.starts_with("pub trait") {
                     Some(s)

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1420,7 +1420,6 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for FnArgTypeVisitor<'c, 's> {
                     .map(destruct_ty_refptr)?;
                 if let Ty::PathSearch(ref path, ref scope) = ty {
                     let segments = &path.segments;
-                    println!("{:?}", segments);
                     // now we want to get 'T' from fn f<T>(){}, so segments.len() == 1
                     if segments.len() == 1 {
                         let name = &segments[0].name;

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -97,7 +97,7 @@ impl<'a> CodeIndicesIter<'a> {
         for &b in &src_bytes[pos.0..] {
             pos = pos.increment();
             if b == b'\n' {
-                if pos.0 + 1 < src_bytes.len() && src_bytes[pos.0..=pos.increment().0] == [b'/', b'/'] {
+                if pos.0 + 2 <= src_bytes.len() && src_bytes[pos.0..pos.0 + 2] == [b'/', b'/'] {
                     continue;
                 }
                 break;

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -235,7 +235,7 @@ pub struct CommentSkipIterRev<'a> {
 }
 
 /// This produce CommentSkipIterRev for range [0, start)
-pub fn comment_skip_iter_rev(s: &str, start: Point) -> CommentSkipIterRev {
+pub fn comment_skip_iter_rev(s: &str, start: BytePos) -> CommentSkipIterRev {
     let start = if start > s.len() { 0 } else { start };
     CommentSkipIterRev { src: s, pos: start }
 }

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -1,4 +1,4 @@
-use core::{Point, SourceByteRange};
+use core::{BytePos, ByteRange};
 
 /// Type of the string
 #[derive(Clone, Copy, Debug)]
@@ -22,20 +22,19 @@ enum State {
 #[derive(Clone,Copy)]
 pub struct CodeIndicesIter<'a> {
     src: &'a str,
-    pos: Point,
+    pos: BytePos,
     state: State
 }
 
 impl<'a> Iterator for CodeIndicesIter<'a> {
-    type Item = SourceByteRange;
+    type Item = ByteRange;
 
-    #[inline]
-    fn next(&mut self) -> Option<SourceByteRange> {
+    fn next(&mut self) -> Option<ByteRange> {
         match self.state {
             State::Code => Some(self.code()),
             State::Comment => Some(self.comment()),
             State::CommentBlock  => Some(self.comment_block()),
-            State::String(level) => Some(self.string(level)),
+            State::String(style) => Some(self.string(style)),
             State::Char => Some(self.char()),
             State::Finished => None
         }
@@ -43,27 +42,26 @@ impl<'a> Iterator for CodeIndicesIter<'a> {
 }
 
 impl<'a> CodeIndicesIter<'a> {
-    fn code(&mut self) -> SourceByteRange {
+    fn code(&mut self) -> ByteRange {
         let mut pos = self.pos;
         let start = match self.state {
-            State::String(_) |
-            State::Char => { pos-1 }, // include quote
-            _ => { pos }
+            State::String(_) | State::Char => pos.decrement(), // include quote
+            _ => pos,
         };
         let src_bytes = self.src.as_bytes();
-        for &b in &src_bytes[pos..] {
-            pos += 1;
+        for &b in &src_bytes[pos.0..] {
+            pos = pos.increment();
             match b {
-                b'/' if src_bytes.len() > pos => match src_bytes[pos] {
+                b'/' if src_bytes.len() > pos.0 => match src_bytes[pos.0] {
                     b'/' => {
                         self.state = State::Comment;
-                        self.pos = pos + 1;
-                        return (start, pos-1);
+                        self.pos = pos.increment();
+                        return ByteRange::new(start, pos.decrement());
                     },
                     b'*' => {
                         self.state = State::CommentBlock;
-                        self.pos = pos + 1;
-                        return (start, pos-1);
+                        self.pos = pos.increment();
+                        return ByteRange::new(start, pos.decrement());
                     },
                     _ => {}
                 },
@@ -71,18 +69,18 @@ impl<'a> CodeIndicesIter<'a> {
                     let str_type = self.detect_str_type(pos);
                     self.state = State::String(str_type);
                     self.pos = pos;
-                    return (start, pos); // include dblquotes
+                    return ByteRange::new(start, pos); // include dblquotes
                 },
                 b'\'' => {
                     // single quotes are also used for lifetimes, so we need to
                     // be confident that this is not a lifetime.
                     // Look for backslash starting the escape, or a closing quote:
-                    if src_bytes.len() > pos + 1 &&
-                        (src_bytes[pos] == b'\\' ||
-                         src_bytes[pos+1] == b'\'') {
+                    if src_bytes.len() > pos.increment().0 &&
+                        (src_bytes[pos.0] == b'\\' ||
+                         src_bytes[pos.increment().0] == b'\'') {
                         self.state = State::Char;
                         self.pos = pos;
-                        return (start, pos); // include single quote
+                        return ByteRange::new(start, pos); // include single quote
                     }
                 },
                 _ => {}
@@ -90,16 +88,16 @@ impl<'a> CodeIndicesIter<'a> {
         }
 
         self.state = State::Finished;
-        (start, self.src.len())
+        ByteRange::new(start, self.src.len().into())
     }
 
-    fn comment(&mut self) -> SourceByteRange {
+    fn comment(&mut self) -> ByteRange {
         let mut pos = self.pos;
         let src_bytes = self.src.as_bytes();
-        for &b in &src_bytes[pos..] {
-            pos += 1;
+        for &b in &src_bytes[pos.0..] {
+            pos = pos.increment();
             if b == b'\n' {
-                if pos + 2 <= src_bytes.len() && src_bytes[pos..pos+2] == [b'/', b'/'] {
+                if pos.0 + 1 < src_bytes.len() && src_bytes[pos.0..=pos.increment().0] == [b'/', b'/'] {
                     continue;
                 }
                 break;
@@ -109,12 +107,12 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn comment_block(&mut self) -> SourceByteRange {
+    fn comment_block(&mut self) -> ByteRange {
         let mut nesting_level = 0usize;
         let mut prev = b' ';
         let mut pos = self.pos;
-        for &b in &self.src.as_bytes()[pos..] {
-            pos += 1;
+        for &b in &self.src.as_bytes()[pos.0..] {
+            pos = pos.increment();
             match b {
                 b'/' if prev == b'*' => {
                     if nesting_level == 0 {
@@ -133,50 +131,65 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn string(&mut self, str_type: StrStyle) -> SourceByteRange {
+    fn string(&mut self, str_type: StrStyle) -> ByteRange {
         let src_bytes = self.src.as_bytes();
         let mut pos = self.pos;
         match str_type {
             StrStyle::Raw(level) => {
-                // raw string (eg br#"\"#)
-                // detect corresponding end(if start is r##", "##) greedily
+                // raw string (e.g. br#"\"#)
+                #[derive(Debug)]
                 enum SharpState {
-                    Sharp((usize, usize)), // (Num of preceding #s, Pos of end ")
+                    Sharp {
+                        // number of preceding #s
+                        num_sharps: usize,
+                        // Position of last "
+                        quote_pos: BytePos
+                    }, 
                     None, // No preceding "##...
                 }
                 let mut cur_state = SharpState::None;
                 let mut end_was_found = false;
-                for (i, &b) in src_bytes[self.pos..].iter().enumerate() {
+                // detect corresponding end(if start is r##", "##) greedily
+                for (i, &b) in src_bytes[self.pos.0..].iter().enumerate() {
                     match cur_state {
-                        SharpState::Sharp((n_sharp, pos_quote)) => {
+                        SharpState::Sharp { num_sharps, quote_pos } => {
                             cur_state = match b {
-                                b'#' => SharpState::Sharp((n_sharp + 1, pos_quote)),
-                                b'"' => SharpState::Sharp((0, i)),
+                                b'#' => SharpState::Sharp {
+                                    num_sharps: num_sharps + 1,
+                                    quote_pos,
+                                },
+                                b'"' => SharpState::Sharp {
+                                    num_sharps: 0,
+                                    quote_pos: BytePos(i),
+                                },
                                 _ => SharpState::None,
                             }
                         }
                         SharpState::None => {
                             if b == b'"' {
-                                cur_state = SharpState::Sharp((0, i));
+                                cur_state = SharpState::Sharp {
+                                    num_sharps: 0,
+                                    quote_pos: BytePos(i),
+                                };
                             }
                         }
                     }
-                    if let SharpState::Sharp((n_sharp, pos_quote)) = cur_state {
-                        if n_sharp == level {
+                    if let SharpState::Sharp { num_sharps, quote_pos } = cur_state {
+                        if num_sharps == level {
                             end_was_found = true;
-                            pos += pos_quote + 1;
+                            pos += quote_pos.increment();
                             break;
                         }
                     }
                 }
                 if !end_was_found {
-                    pos = src_bytes.len();
+                    pos = src_bytes.len().into();
                 }
             }
             StrStyle::Cooked => {
                 let mut is_not_escaped = true;
-                for &b in &src_bytes[pos..] {
-                    pos += 1;
+                for &b in &src_bytes[pos.0..] {
+                    pos = pos.increment();
                     match b {
                         b'"' if is_not_escaped  => { break; }, // "
                         b'\\' => { is_not_escaped = !is_not_escaped; },
@@ -189,11 +202,11 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn char(&mut self) -> SourceByteRange {
+    fn char(&mut self) -> ByteRange {
         let mut is_not_escaped = true;
         let mut pos = self.pos;
-        for &b in &self.src.as_bytes()[pos..] {
-            pos += 1;
+        for &b in &self.src.as_bytes()[pos.0..] {
+            pos = pos.increment();
             match b {
                 b'\'' if is_not_escaped  => { break; },
                 b'\\' => { is_not_escaped = !is_not_escaped; },
@@ -204,14 +217,14 @@ impl<'a> CodeIndicesIter<'a> {
         self.code()
     }
 
-    fn detect_str_type(&self, pos: usize) -> StrStyle {
+    fn detect_str_type(&self, pos: BytePos) -> StrStyle {
         let src_bytes = self.src.as_bytes();
         let mut sharp = 0;
-        if pos == 0 {
+        if pos == BytePos::ZERO {
             return StrStyle::Cooked;
         }
         // now pos is at one byte after ", so we have to start at pos - 2
-        for &b in src_bytes[..pos - 1].iter().rev() {
+        for &b in src_bytes[..pos.decrement().0].iter().rev() {
             match b {
                 b'#' => sharp += 1,
                 b'r' => return StrStyle::Raw(sharp),
@@ -224,37 +237,37 @@ impl<'a> CodeIndicesIter<'a> {
 
 /// Returns indices of chunks of code (minus comments and string contents)
 pub fn code_chunks(src: &str) -> CodeIndicesIter {
-    CodeIndicesIter { src, state: State::Code, pos: 0 }
+    CodeIndicesIter { src, state: State::Code, pos: BytePos::ZERO }
 }
 
 /// Reverse Iterator for reading the source bytes skipping comments.
 /// This is written for get_start_of_pattern and maybe not so robust.
 pub struct CommentSkipIterRev<'a> {
     src: &'a str,
-    pos: Point,
+    pos: BytePos,
 }
 
 /// This produce CommentSkipIterRev for range [0, start)
 pub fn comment_skip_iter_rev(s: &str, start: BytePos) -> CommentSkipIterRev {
-    let start = if start > s.len() { 0 } else { start };
+    let start = if start.0 > s.len() { BytePos::ZERO } else { start };
     CommentSkipIterRev { src: s, pos: start }
 }
 
 impl<'a> Iterator for CommentSkipIterRev<'a> {
-    type Item = (char, Point);
-    fn next(&mut self) -> Option<(char, Point)> {
+    type Item = (char, BytePos);
+    fn next(&mut self) -> Option<(char, BytePos)> {
         let cur_byte = self.cur_byte()?;
         match cur_byte {
             b'\n' => {
                 let pos = self.pos;
                 self.pos = self.skip_line_comment();
-                Some((cur_byte as char, pos - 1))
+                Some((cur_byte as char, pos.decrement()))
             }
             b'/' => {
-                if let Some(next_byte) = self.get_byte(self.pos - 1) {
+                if let Some(next_byte) = self.get_byte(self.pos.decrement()) {
                     if next_byte == b'*' {
                         self.pos = self.skip_block_comment();
-                        Some((self.cur_byte()? as char, self.pos - 1))
+                        Some((self.cur_byte()? as char, self.pos.decrement()))
                     } else {
                         self.code()
                     }
@@ -273,31 +286,31 @@ impl<'a> CommentSkipIterRev<'a> {
         self.get_byte(self.pos)
     }
 
-    fn code(&mut self) -> Option<(char, Point)> {
+    fn code(&mut self) -> Option<(char, BytePos)> {
         let cur_byte = self.cur_byte()?;
-        self.pos -= 1;
+        self.pos = self.pos.decrement();
         Some((cur_byte as char, self.pos))
     }
 
-    fn get_byte(&self, p: Point) -> Option<u8> {
-        if p == 0 {
+    fn get_byte(&self, p: BytePos) -> Option<u8> {
+        if p == BytePos::ZERO {
             None
         } else {
-            let b = self.src.as_bytes()[p - 1];
+            let b = self.src.as_bytes()[p.0 - 1];
             Some(b)
         }
     }
 
     // return where 'pos' shuld be after skipping block comments
-    fn skip_block_comment(&self) -> Point {
+    fn skip_block_comment(&self) -> BytePos {
         let mut nest_level = 0;
         let mut prev = b' ';
-        for i in (0..self.pos - 2).rev() {
+        for i in (0..self.pos.0 - 2).rev() {
             let b = self.src.as_bytes()[i];
             match b {
                 b'/' if prev == b'*' => {
                     if nest_level == 0 {
-                        return i;
+                        return i.into();
                     } else {
                         nest_level -= 1;
                     }
@@ -310,39 +323,39 @@ impl<'a> CommentSkipIterRev<'a> {
                 }
             }
         }
-        0
+        BytePos::ZERO
     }
 
     // return where 'pos' shuld be after skipping line comments
-    fn skip_line_comment(&self) -> Point {
-        let skip_cr = |p: Point| -> Point {
+    fn skip_line_comment(&self) -> BytePos {
+        let skip_cr = |p: BytePos| -> BytePos {
             if let Some(b) = self.get_byte(p) {
                 if b == b'\r' {
-                    return p - 1;
+                    return p.decrement();
                 }
             }
             p
         };
         let mut pos = self.pos;
         let mut skipped_whole_line = true;
-        while skipped_whole_line && pos > 0 {
+        while skipped_whole_line && pos > BytePos::ZERO {
             // now pos >= 1 && self.src.as_bytes()[pos - 1] == '\n'
             skipped_whole_line = false;
-            let comment_start = if let Some(next_newline) = self.src[..pos - 1].rfind('\n') {
-                if let Some(start) = self.src[next_newline + 1..pos - 1].find("//") {
+            let comment_start = if let Some(next_newline) = self.src[..pos.decrement().0].rfind('\n') {
+                if let Some(start) = self.src[next_newline + 1..pos.decrement().0].find("//") {
                     skipped_whole_line = start == 0;
                     start + next_newline + 1
                 } else {
-                    return skip_cr(pos - 1);
+                    return skip_cr(pos.decrement());
                 }
             } else {
-                if let Some(start) = self.src[..pos - 1].find("//") {
+                if let Some(start) = self.src[..pos.decrement().0].find("//") {
                     start
                 } else {
-                    return skip_cr(pos - 1);
+                    return skip_cr(pos.decrement());
                 }
             };
-            pos = comment_start;
+            pos = BytePos(comment_start);
         }
         pos
     }
@@ -482,10 +495,11 @@ mod code_indices_iter_test {
         more_code(\" skip me \")
     ");
 
-        for (start, end) in code_chunks(src) {
-            println!("BLOB |{}|", &src[start..end]);
-            if src[start..end].contains("skip me") {
-                panic!("{}", &src[start..end]);
+        for range in code_chunks(src) {
+            let range = || range.to_range();
+            println!("BLOB |{}|", &src[range()]);
+            if src[range()].contains("skip me") {
+                panic!("{}", &src[range()]);
             }
         }
     }
@@ -515,7 +529,7 @@ mod comment_skip_iter_rev_test {
     // another comment
     some more code
     ");
-        let result: String = comment_skip_iter_rev(&src, src.len()).map(|c| c.0).collect();
+        let result: String = comment_skip_iter_rev(&src, BytePos(src.len())).map(|c| c.0).collect();
         assert_eq!(&result, "edoc erom emos\n edoc emos si siht");
     }
     #[test]
@@ -525,7 +539,7 @@ mod comment_skip_iter_rev_test {
     /* /* nested comment */ */
     some more code
     ");
-        let result: String = comment_skip_iter_rev(&src, src.len()).map(|c| c.0).collect();
+        let result: String = comment_skip_iter_rev(&src, BytePos(src.len())).map(|c| c.0).collect();
         assert_eq!(&result, "edoc erom emos\n\n\n edoc emos si siht");
     }
     #[test]
@@ -534,7 +548,7 @@ mod comment_skip_iter_rev_test {
     this is some code /* this is a
     \"multiline\" comment */some more code
     ");
-        let result: String = comment_skip_iter_rev(&src, src.len()).map(|c| c.0).collect();
+        let result: String = comment_skip_iter_rev(&src, BytePos(src.len())).map(|c| c.0).collect();
         assert_eq!(&result, "edoc erom emos  edoc emos si siht");
     }
 }

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -137,7 +137,7 @@ impl<'a, I> StmtIndicesIter<'a,I>
     where I: Iterator<Item = ByteRange>
 {
     pub fn from_parts(src: &str, it: I) -> Fuse<StmtIndicesIter<I>> {
-        StmtIndicesIter{ src, it, pos: BytePos::zero(), end: BytePos::zero() }.fuse()
+        StmtIndicesIter{ src, it, pos: BytePos::ZERO, end: BytePos::ZERO }.fuse()
     }
 }
 
@@ -153,7 +153,7 @@ mod test {
 
     fn iter_stmts(src: &str) -> Fuse<StmtIndicesIter<codecleaner::CodeIndicesIter>> {
         let it = codecleaner::code_chunks(src);
-        StmtIndicesIter{ src: src, it: it, pos: 0, end: 0 }.fuse()
+        StmtIndicesIter{ src: src, it: it, pos: BytePos::ZERO, end: BytePos::ZERO }.fuse()
     }
 
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1152,7 +1152,7 @@ fn complete_from_file_(
     };
 
     let start = scopes::get_start_of_search_expr(src_text, pos);
-    let expr = &src_text[start..pos];
+    let expr = &src_text[start.0..pos.0];
 
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
@@ -1171,7 +1171,7 @@ fn complete_from_file_(
 
             // step 1, get full line, take the rightmost part split by semicolon
             //   prevent the case that someone write multiple line in one line
-            let line = src_text[linestart..pos].trim().rsplit(';').nth(0).unwrap();
+            let line = src_text[linestart.0..pos.0].trim().rsplit(';').nth(0).unwrap();
             debug!("Complete path with line: {:?}", line);
 
             // Test if the **path expression** starts with `::`, in which case the path
@@ -1321,8 +1321,8 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
     };
 
     // Make sure `src` is in the cache
-    let (start, end) = scopes::expand_search_expr(src, pos);
-    let expr = &src[start..end];
+    let range = scopes::expand_search_expr(src, pos);
+    let expr = &src[range.to_range()];
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
     debug!("find_definition_ for |{:?}| |{:?}| {:?}", contextstr, searchstr, completetype);
@@ -1349,7 +1349,7 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
             debug!("context is {:?}", context);
 
-            let match_type:MatchType = if src[end..].starts_with('(') { MatchType::Function } else { MatchType::StructField };
+            let match_type:MatchType = if src[range.end.0..].starts_with('(') { MatchType::Function } else { MatchType::StructField };
             context.and_then(|ty| {
                 // for now, just handle matches
                 if let Ty::Match(m) = ty {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -104,6 +104,12 @@ impl BytePos {
     }
 }
 
+impl fmt::Display for BytePos {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// 0-based byte range in a file.
 /// start: inclusive end: exclusive i.e. [start, end)
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
@@ -1298,7 +1304,6 @@ pub fn find_definition<P, C>(
                 let src = session.load_file(m.filepath.as_path());
                 m.coords = src.point_to_coords(point);
             }
-
             m
         })
 }

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -1,12 +1,18 @@
 #![feature(iterator_flatten)]
+#![feature(slice_get_slice)]
 #![cfg_attr(all(feature = "clippy", not(test)), deny(print_stdout))]
 #![cfg_attr(feature = "nightly", feature(test))]
 
-#[macro_use] extern crate log;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate lazy_static;
 
 extern crate cargo;
 extern crate syntax;
+#[macro_use]
+extern crate derive_more;
+extern crate rls_span;
 
 #[macro_use]
 mod testutils;

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -32,7 +32,7 @@ mod fileres;
 pub use core::{find_definition, complete_from_file, complete_fully_qualified_name, to_point, to_coords};
 pub use snippets::snippet_for_match;
 pub use core::{Match, MatchType, PathSearch};
-pub use core::{FileCache, Session, Coordinate, Location, FileLoader, Point, SourceByteRange};
+pub use core::{FileCache, Session, Coordinate, Location, FileLoader, BytePos, ByteRange};
 pub use util::expand_ident;
 
 pub use util::{RustSrcPathError, get_rust_src_path};

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -106,7 +106,7 @@ fn find_keyword(src: &str, pattern: &str, context: &MatchCxt) -> Option<BytePos>
     // if not local must start with pub
     if !context.is_local && !src.starts_with("pub") { return None; }
 
-    let mut start = BytePos::zero();
+    let mut start = BytePos::ZERO;
 
     // optional (pub\s+)?(unsafe\s+)?
     for pat in &["pub", "unsafe"] {
@@ -306,14 +306,14 @@ pub fn match_extern_crate(msrc: &str, context: &MatchCxt, session: &Session) -> 
                 let crate_src = session.load_file(&cratepath);
                 res = Some(Match { matchstr: name.clone(),
                                   filepath: cratepath.to_path_buf(),
-                                  point: BytePos::zero(),
+                                  point: BytePos::ZERO,
                                   coords: Some(Coordinate::start()),
                                   local: false,
                                   mtype: Module,
                                   contextstr: cratepath.to_str().unwrap().to_owned(),
                                   generic_args: Vec::new(),
                                   generic_types: Vec::new(),
-                                  docs: find_mod_doc(&crate_src, BytePos::zero()),
+                                  docs: find_mod_doc(&crate_src, BytePos::ZERO),
                 });
             }
         }
@@ -353,14 +353,14 @@ pub fn match_mod(msrc: Src, context: &MatchCxt, session: &Session) -> Option<Mat
             return Some(Match {
                 matchstr: s,
                 filepath: modpath.to_path_buf(),
-                point: BytePos::zero(),
+                point: BytePos::ZERO,
                 coords: Some(Coordinate::start()),
                 local: false,
                 mtype: Module,
                 contextstr: modpath.to_str().unwrap().to_owned(),
                 generic_args: Vec::new(),
                 generic_types: Vec::new(),
-                docs: find_mod_doc(&msrc, BytePos::zero()),
+                docs: find_mod_doc(&msrc, BytePos::ZERO),
             })
         }
         // get internal module nesting
@@ -378,14 +378,14 @@ pub fn match_mod(msrc: Src, context: &MatchCxt, session: &Session) -> Option<Mat
             return Some(Match {
                 matchstr: s,
                 filepath: modpath,
-                point: BytePos::zero(),
+                point: BytePos::ZERO,
                 coords: Some(Coordinate::start()),
                 local: false,
                 mtype: Module,
                 contextstr: context,
                 generic_args: Vec::new(),
                 generic_types: Vec::new(),
-                docs: find_mod_doc(&msrc, 0),
+                docs: find_mod_doc(&msrc, BytePos::ZERO),
             })
         }
     }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -561,7 +561,6 @@ fn search_scope_headers(
                 }
             }
             return out.into_iter();
-            // FIX_BEFORE_PR: should remove
         } else if let Some(vec) = search_closure_args(search_str, preblock, stmtstart, filepath, search_type) {
             return vec.into_iter();
         }
@@ -1088,6 +1087,12 @@ fn run_matchers_on_blob(
     session: &Session,
     pending_imports: &PendingImports
 ) -> Vec<Match> {
+    debug!(
+        "[run_matchers_on_blob] src: {}, cxt: {:?}, namespace: {:?}",
+        &src[context.range.to_range()],
+        context,
+        namespace
+    );
     let mut out = Vec::new();
     match namespace {
         Namespace::Type =>
@@ -1290,8 +1295,6 @@ pub fn resolve_name(
     let mut out = Vec::new();
     let searchstr = &pathseg.name;
 
-    debug!("resolve_name {} {:?} {:?} {:?} {:?}", searchstr, filepath.display(), pos, search_type, namespace);
-
     let msrc = session.load_file(filepath);
     let is_exact_match = match search_type { ExactMatch => true, StartsWith => false };
 
@@ -1458,7 +1461,7 @@ pub fn resolve_path(
                     let scopesrc = filesrc.get_src_from_start(scopestart);
                     if let Some(blob_range) = scopesrc.iter_stmts().nth(0) {
                         let match_cxt = MatchCxt {
-                            filepath,
+                            filepath: &m.filepath,
                             search_str: &pathseg.name,
                             search_type,
                             range: blob_range.shift(scopestart),

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -48,7 +48,7 @@ pub fn scope_start(src: Src, point: BytePos) -> BytePos {
 
     // We've found a multi-use statement, such as `use foo::{bar, baz};`, so we shouldn't consider
     // the brace to be the start of the scope.
-    if curly_parent_open_pos > BytePos(0) && masked_src[..curly_parent_open_pos.0].ends_with("::{") {
+    if curly_parent_open_pos > BytePos::ZERO && masked_src[..curly_parent_open_pos.0].ends_with("::{") {
         trace!("scope_start landed in a use statement for {:?}; broadening search", point);
         curly_parent_open_pos = find_close(
             mask_comments(src.change_length(curly_parent_open_pos.decrement())).as_bytes().iter().rev(), 
@@ -428,7 +428,7 @@ pub fn mask_comments(src: Src) -> String {
     if src.len() > prev.0 {
         fill_gaps(buffer, &mut result, src.len(), prev.0);
     }
-
+    assert_eq!(src.len(), result.len());
     result
 }
 

--- a/src/racer/testutils.rs
+++ b/src/racer/testutils.rs
@@ -1,7 +1,6 @@
-#[cfg(test)]
-use core::SourceByteRange;
+#![cfg(test)]
+use core::ByteRange;
 
-#[cfg(test)]
 pub fn rejustify(src: &str) -> String {
     let s = &src[1..]; // remove the newline
     let mut sb = String::new();
@@ -17,7 +16,6 @@ pub fn rejustify(src: &str) -> String {
     sb
 }
 
-#[cfg(test)]
-pub fn slice(src: &str, (begin, end): SourceByteRange) -> &str {
-    &src[begin..end]
+pub fn slice(src: &str, range: ByteRange) -> &str {
+    &src[range.to_range()]
 }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -266,7 +266,6 @@ fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
 
         let pos = m.point + BytePos(8) - stmtstart - forpos.into() - range.start;
         let scope = Scope{ filepath: m.filepath.clone(), point: stmtstart };
-
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
@@ -306,7 +305,6 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &Ses
 
 pub fn get_tuplestruct_field_type(fieldnum: usize, structmatch: &Match, session: &Session) -> Option<core::Ty> {
     let src = session.load_file(&structmatch.filepath);
-
     let structsrc = if let core::MatchType::EnumVariant(_) = structmatch.mtype {
         // decorate the enum variant src to make it look like a tuple struct
         let to = src[structmatch.point.0..].find('(')

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -11,7 +11,7 @@ use core::SearchType::ExactMatch;
 use util::{self, txt_matches};
 use std::path::Path;
 
-// FIX_BEFORE_PR: Option
+// TODO: Option
 fn find_start_of_function_body(src: &str) -> BytePos {
     // TODO: this should ignore anything inside parens so as to skip the arg list
     src.find('{')
@@ -101,7 +101,7 @@ pub fn get_type_of_self(
     msrc: Src,
     session: &Session
 ) -> Option<core::Ty> {
-    scopes::find_impl_start(msrc, point, BytePos::zero()).and_then(|start| {
+    scopes::find_impl_start(msrc, point, BytePos::ZERO).and_then(|start| {
         let decl = generate_skeleton_for_parsing(&msrc.shift_start(start));
         debug!("get_type_of_self_arg impl skeleton |{}|", decl);
 
@@ -264,7 +264,7 @@ fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
             range.start
         );
 
-        let pos = m.point + BytePos::from(8) - stmtstart - forpos.into() - range.start;
+        let pos = m.point + BytePos(8) - stmtstart - forpos.into() - range.start;
         let scope = Scope{ filepath: m.filepath.clone(), point: stmtstart };
 
         ast::get_let_type(blob.to_owned(), pos, scope, session)
@@ -369,7 +369,7 @@ pub fn get_type_from_match_arm(m: &Match, msrc: Src, session: &Session) -> Optio
     // match stmt may be incomplete (half written) in the real code
 
     // skip to end of match arm pattern so we can search backwards
-    let arm = msrc[m.point.0..].find("=>")?.into() + m.point;
+    let arm = BytePos(msrc[m.point.0..].find("=>")?) + m.point;
     let scopestart = scopes::scope_start(msrc, arm);
 
     let stmtstart = scopes::find_stmt_start(msrc, scopestart.decrement())?;

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -3,7 +3,7 @@ use std::{cmp, error, fmt, path};
 use std::rc::Rc;
 use std::{collections::hash_map::DefaultHasher, hash::{Hash, Hasher}};
 
-use core::{IndexedSource, Session, SessionExt, Location, LocationExt, Point};
+use core::{IndexedSource, Session, SessionExt, Location, LocationExt, BytePos};
 use core::SearchType::{self, ExactMatch, StartsWith};
 
 #[cfg(unix)]
@@ -26,6 +26,7 @@ pub fn is_ident_char(c: char) -> bool {
 /// Searches for `needle` as a standalone identifier in `haystack`. To be considered a match,
 /// the `needle` must occur either at the beginning of `haystack` or after a non-identifier
 /// character.
+// TODO: this function should returns the position of found keyword
 pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
     match stype {
         ExactMatch => {
@@ -182,8 +183,8 @@ pub fn expand_ident<P, C>(
         // TODO: Would this better be an assertion ? Why are out-of-bound values getting here ?
         // They are coming from the command-line, question is, if they should be handled beforehand
         // clamp pos into allowed range
-        let pos = cmp::min(s.len(), pos);
-        let sb = &s[..pos];
+        let pos = cmp::min(s.len().into(), pos);
+        let sb = &s[..pos.0];
         let mut start = pos;
 
         // backtrack to find start of word
@@ -191,7 +192,7 @@ pub fn expand_ident<P, C>(
             if !is_ident_char(c) {
                 break;
             }
-            start = i;
+            start = i.into();
         }
 
         (start, pos)
@@ -206,33 +207,33 @@ pub fn expand_ident<P, C>(
 
 pub struct ExpandedIdent {
     src: Rc<IndexedSource>,
-    start: Point,
-    pos: Point,
+    start: BytePos,
+    pos: BytePos,
 }
 
 impl ExpandedIdent {
     pub fn ident(&self) -> &str {
-        &self.src.code[self.start..self.pos]
+        &self.src.code[self.start.0..self.pos.0]
     }
 
-    pub fn start(&self) -> Point {
+    pub fn start(&self) -> BytePos {
         self.start
     }
 
-    pub fn pos(&self) -> Point {
+    pub fn pos(&self) -> BytePos {
         self.pos
     }
 }
 
-pub fn find_ident_end(s: &str, pos: Point) -> Point {
+pub fn find_ident_end(s: &str, pos: BytePos) -> BytePos {
     // find end of word
-    let sa = &s[pos..];
+    let sa = &s[pos.0..];
     for (i, c) in sa.char_indices() {
         if !is_ident_char(c) {
-            return pos + i;
+            return pos + i.into();
         }
     }
-    s.len()
+    s.len().into()
 }
 
 #[test]

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -153,7 +153,7 @@ fn txt_matches_matches_methods() {
 /// extern crate racer;
 ///
 /// let src = "let x = this_is_an_identifier;";
-/// let pos = racer::Location::Point(29);
+/// let pos = racer::Location::from(29);
 /// let path = "lib.rs";
 ///
 /// let cache = racer::FileCache::default();

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -109,10 +109,10 @@ fn completes_fn_with_substitute_file() {
     let real_file = Path::new("not_real.rs");
     let session = racer::Session::new(&cache);
     session.cache_file_contents(&real_file, src);
-    let cursor = Coordinate { line: 6, column: 18 };
+    let cursor = Coordinate::new(6, 18);
     let got = complete_from_file(real_file, cursor, &session).nth(0).unwrap();
 
-    assert_eq!(Some(Coordinate { line: 2, column: 8 }), got.coords);
+    assert_eq!(Some(Coordinate::new(2, 8)), got.coords);
     assert_eq!("apple", got.matchstr);
 }
 
@@ -212,7 +212,7 @@ fn completes_local_scope_let() {
 
     let got = get_one_completion(src, None);
     assert_eq!("apple", got.matchstr);
-    assert_eq!(29, got.point);
+    assert_eq!(29, got.point.0);
 }
 
 #[test]
@@ -227,7 +227,7 @@ fn completes_via_parent_scope_let() {
 
     let got = get_one_completion(src, None);
     assert_eq!("apple", got.matchstr);
-    assert_eq!(33, got.point);
+    assert_eq!(33, got.point.0);
 }
 
 #[test]
@@ -295,11 +295,11 @@ fn completes_for_vec_field_and_method() {
     let path = dir.write_file("src.rs", src);
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
-    let cursor1 = Coordinate { line: 22, column: 18 };
+    let cursor1 = Coordinate::new(22, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
     println!("{:?}", got1);
     assert_eq!("stfield", got1.matchstr);
-    let cursor2 = Coordinate { line: 23, column: 18 };
+    let cursor2 = Coordinate::new(23, 18);
     let got2 = complete_from_file(&path, cursor2, &session).nth(0).unwrap();
     println!("{:?}", got2);
     assert_eq!("stmethod", got2.matchstr);
@@ -332,11 +332,11 @@ fn completes_trait_methods() {
     let path = f.path();
     let cache1 = racer::FileCache::default();
     let session1 = racer::Session::new(&cache1);
-    let cursor1 = Coordinate { line: 18, column: 18};
+    let cursor1 = Coordinate::new(18, 18);
     let got1 = complete_from_file(&path, cursor1, &session1).nth(0).unwrap();
     let cache2 = racer::FileCache::default();
     let session2 = racer::Session::new(&cache2);
-    let cursor2 = Coordinate { line: 19, column: 11};
+    let cursor2 = Coordinate::new(19, 11);
     let got2 = complete_from_file(&path, cursor2, &session2).nth(0).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
@@ -374,11 +374,11 @@ fn completes_trait_bounded_methods() {
     let path = f.path();
     let cache1 = racer::FileCache::default();
     let session1 = racer::Session::new(&cache1);
-    let cursor1 = Coordinate { line: 20, column: 16 };
+    let cursor1 = Coordinate::new(20, 16);
     let got1 = complete_from_file(&path, cursor1, &session1).nth(0).unwrap();
     let cache2 = racer::FileCache::default();
     let session2 = racer::Session::new(&cache2);
-    let cursor2 = Coordinate { line: 21, column: 12 };
+    let cursor2 = Coordinate::new(21, 12);
     let got2 = complete_from_file(&path, cursor2, &session2).nth(0).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
@@ -421,8 +421,8 @@ fn completes_trait_bounded_methods_generic_return() {
     let path = f.path();
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
-    let cursor1 = Coordinate { line: 24, column: 24 };
-    let cursor2 = Coordinate { line: 25, column: 25 };
+    let cursor1 = Coordinate::new(24, 24);
+    let cursor2 = Coordinate::new(25, 25);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
     let got2 = complete_from_file(&path, cursor2, &session).nth(0).unwrap();
     println!("{:?}", got1);
@@ -594,11 +594,11 @@ fn completes_for_vec_iter_field_and_method() {
     let path = dir.write_file("src.rs", src);
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
-    let cursor1 = Coordinate { line: 22, column: 18 };
+    let cursor1 = Coordinate::new(22, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
     println!("{:?}", got1);
     assert_eq!("stfield", got1.matchstr);
-    let cursor2 = Coordinate { line: 23, column: 18 };
+    let cursor2 = Coordinate::new(23, 18);
     let got2 = complete_from_file(&path, cursor2, &session).nth(0).unwrap();
     println!("{:?}", got2);
     assert_eq!("stmethod", got2.matchstr);
@@ -632,9 +632,9 @@ fn completes_trait_methods_when_at_scope_end() {
     let path = f.path();
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
-    let cursor1 = Coordinate { line: 18, column: 18 };
+    let cursor1 = Coordinate::new(18, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
-    let cursor2 = Coordinate { line: 19, column: 11 };
+    let cursor2 = Coordinate::new(19, 11);
     let got2 = complete_from_file(&path, cursor2, &session).nth(0).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
@@ -828,8 +828,8 @@ fn single_import_shadows_glob_import() {
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "Foo");
     println!("{}", got.filepath.display());
-    println!("{}", got.point);
-    assert_eq!(got.coords, Some(Coordinate { line: 10, column: 19 }));
+    println!("{:?}", got.point);
+    assert_eq!(got.coords, Some(Coordinate::new(10, 19)));
 }
 
 #[test]
@@ -1349,7 +1349,7 @@ fn follows_self_use() {
     let got = get_definition(src, Some(dir));
     assert_eq!(got.matchstr, "myfn");
     assert_eq!(src4file.path(), got.filepath);
-    assert_eq!(28, got.point);
+    assert_eq!(28, got.point.0);
 }
 
 #[test]
@@ -1421,7 +1421,7 @@ fn follows_use_to_impl() {
     let mod_path = dir.write_file("mymod.rs", modsrc);
     let got = get_definition(src, Some(dir));
     assert_eq!(got.matchstr, "new");
-    assert_eq!(90, got.point);
+    assert_eq!(90, got.point.0);
     assert_eq!(mod_path.path(), got.filepath);
 }
 
@@ -2054,7 +2054,7 @@ fn doesnt_find_if_let_if_not_in_the_subscope() {
 
     let got = get_definition(src, None);
     assert_eq!("myvar", got.matchstr);
-    assert_eq!(9, got.point);
+    assert_eq!(9, got.point.0);
 }
 
 #[test]
@@ -2067,7 +2067,7 @@ fn finds_rebound_var_in_iflet() {
     ";
 
     let got = get_definition(src, None);
-    assert_eq!(56, got.point);
+    assert_eq!(56, got.point.0);
 }
 
 #[test]
@@ -2190,7 +2190,7 @@ fn handles_default_arm() {
 
     let got = get_definition(src, None);
     assert_eq!("o", got.matchstr);
-    assert_eq!(9, got.point);
+    assert_eq!(9, got.point.0);
 }
 
 #[test]
@@ -2202,7 +2202,7 @@ fn doesnt_match_rhs_of_let_in_same_stmt() {
 
     let got = get_definition(src, None);
     assert_eq!("a", got.matchstr);
-    assert_eq!(9, got.point);
+    assert_eq!(9, got.point.0);
 }
 
 #[test]
@@ -2217,7 +2217,7 @@ fn finds_unsafe_fn() {
 
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "foo");
-    assert_eq!(got.point, 15);
+    assert_eq!(got.point.0, 15);
 }
 
 #[test]
@@ -2861,7 +2861,7 @@ fn closure_scope_dont_match_type_annotations() {
     let got = get_definition(src, None);
     println!("{:?}", got);
     assert_eq!(MatchType::Struct, got.mtype);
-    assert_eq!(2, got.coords.unwrap().line);
+    assert_eq!(2, got.coords.unwrap().row.0);
 }
 
 /// The variable `i` doesn't exist in `foo`, so trying to get the definition should

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -1,7 +1,7 @@
 //! system test utilities for racer
 extern crate racer;
 extern crate tempfile;
-use racer::{complete_from_file, find_definition, Match, Point};
+use racer::{complete_from_file, find_definition, Match, BytePos};
 use std::fmt;
 use std::fs;
 use std::io::{self, Write};
@@ -175,9 +175,9 @@ pub fn with_test_project<F: FnOnce(TmpDir)>(test: F)
 }
 
 /// get position where you want to test completion and source code
-pub fn get_pos_and_source(src: &str) -> (Point, String) {
+pub fn get_pos_and_source(src: &str) -> (BytePos, String) {
     let point = src.find('~').unwrap();
-    (point, src.replace('~', ""))
+    (point.into(), src.replace('~', ""))
 }
 
 /// Return the completions for the given source.


### PR DESCRIPTION
- use `struct BytePos(usize)` instead of `type Point = usize` (#742)
- use `struct ByteRange` instead of `type SourceByteRange = (Point, Point)` (also #742)
- use rls-span in Coordinate (#661)
- refactor some codes using these types(e.g. now all matcher functions take `MatchCxt`, to make it easier to have additional flags)