### PR TITLE
[matcher] handle const unsafe fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer-testutils 0.1.0",
+ "regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-ap-syntax 184.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -784,8 +785,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1357,7 +1378,9 @@ dependencies = [
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13c93d55961981ba9226a213b385216f83ab43bd6ac53ab16b2eeb47e337cf4e"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
+"checksum regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05b06a75f5217880fc5e905952a42750bf44787e56a6c6d6852ed0992f5e1d54"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rustc-ap-arena 184.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e6f8e3aa4e413969d37afdd897c36d18606d83d9562454e6f9391af5a1344a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lazy_static = "1.0"
 humantime = "1.1"
 derive_more = "0.11.0"
 rls-span = "0.4.0"
+regex = "1.0"
 
 [dev-dependencies]
 racer-testutils = { path = "testutils" }

--- a/src/racer/fileres.rs
+++ b/src/racer/fileres.rs
@@ -1,7 +1,7 @@
 use cargo::core::{
     registry::PackageRegistry, resolver::{EncodableResolve, Method, Resolve}, Workspace,
 };
-use cargo::ops::{self, resolve_with_previous};
+use cargo::ops::resolve_with_previous;
 use cargo::util::{errors::CargoResult, important_paths::find_root_manifest_for_wd, toml};
 use cargo::Config;
 use core::Session;

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -12,6 +12,7 @@ extern crate cargo;
 extern crate syntax;
 #[macro_use]
 extern crate derive_more;
+extern crate regex;
 extern crate rls_span;
 
 #[macro_use]

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4046,3 +4046,13 @@ fn recursive_glob_depth5() {
     let got = get_definition(src, None);
     assert_eq!("MyVariant", got.matchstr);
 }
+
+#[test]
+fn completes_const_unsafe_fn() {
+    let src = r"
+    const unsafe fn unsafe_func() {}
+    let var = unsafe_fu~
+";
+    let got = get_only_completion(src, None);
+    assert_eq!("unsafe_func", got.matchstr);
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4056,9 +4056,20 @@ fn completes_const_unsafe_fn() {
     let got = get_only_completion(src, None);
     assert_eq!("unsafe_func", got.matchstr);
     let src = r"
-    const    unsafe   fn   unsafe_func() {}
+    pub const    unsafe   fn   unsafe_func() {}
     let var = unsafe_fu~
 ";
     let got = get_only_completion(src, None);
     assert_eq!("unsafe_func", got.matchstr);
 }
+
+#[test]
+fn completes_fn_with_crate_visibility_modifier() {
+    let src = r"
+    crate unsafe fn unsafe_func() {}
+    let var = unsafe_fu~
+";
+    let got = get_only_completion(src, None);
+    assert_eq!("unsafe_func", got.matchstr);
+}
+

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4055,4 +4055,10 @@ fn completes_const_unsafe_fn() {
 ";
     let got = get_only_completion(src, None);
     assert_eq!("unsafe_func", got.matchstr);
+    let src = r"
+    const    unsafe   fn   unsafe_func() {}
+    let var = unsafe_fu~
+";
+    let got = get_only_completion(src, None);
+    assert_eq!("unsafe_func", got.matchstr);
 }


### PR DESCRIPTION
For #877
But now it's not perfect.
Because of `find_keyword`'s restriction, this code searches `const unsafe` so it's not robust.
`find_keyword` should take regex or set of string instead of string