### PR TITLE
Add stdlib benchmark

### DIFF
--- a/benches/bench_stdlibs.rs
+++ b/benches/bench_stdlibs.rs
@@ -33,6 +33,7 @@ fn completes_methods_for_file_open(b: &mut Bencher) {
     let src = r#"
     use std::io;
     use std::io::prelude::*;
+    use std::fs::File;
     let mut f = File::open("no-file-here"):
     f.~
 "#;

--- a/benches/bench_stdlibs.rs
+++ b/benches/bench_stdlibs.rs
@@ -1,0 +1,43 @@
+#![feature(test)]
+extern crate racer_testutils;
+extern crate test;
+use test::Bencher;
+
+use racer_testutils::*;
+
+#[bench]
+fn completes_hashmap(b: &mut Bencher) {
+    let src = r"
+    use std::collections::HashM~
+";
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}
+
+#[bench]
+fn completes_methods_for_vec(b: &mut Bencher) {
+    let src = r"
+    let vec = Vec::new();
+    let a = vec.~
+";
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}
+
+#[bench]
+fn completes_methods_for_file_open(b: &mut Bencher) {
+    let src = r#"
+    use std::io;
+    use std::io::prelude::*;
+    let mut f = File::open("no-file-here"):
+    f.~
+"#;
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}


### PR DESCRIPTION
Here's the result:
```
running 3 tests
test completes_hashmap               ... bench:     685,075 ns/iter (+/- 13,783)
test completes_methods_for_file_open ... bench:     644,133 ns/iter (+/- 43,428)
test completes_methods_for_vec       ... bench:  98,868,577 ns/iter (+/- 2,346,717)
```
But, hmm, I don't know why method completion for vec is really slow.
