### PR TITLE
Remove regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,6 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer-testutils 0.1.0",
- "regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-ap-syntax 184.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -785,28 +784,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1378,9 +1357,7 @@ dependencies = [
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
-"checksum regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13c93d55961981ba9226a213b385216f83ab43bd6ac53ab16b2eeb47e337cf4e"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
-"checksum regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05b06a75f5217880fc5e905952a42750bf44787e56a6c6d6852ed0992f5e1d54"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"
 "checksum rustc-ap-arena 184.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e6f8e3aa4e413969d37afdd897c36d18606d83d9562454e6f9391af5a1344a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ lazy_static = "1.0"
 humantime = "1.1"
 derive_more = "0.11.0"
 rls-span = "0.4.0"
-regex = "1.0"
 
 [dev-dependencies]
 racer-testutils = { path = "testutils" }

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -12,7 +12,6 @@ extern crate cargo;
 extern crate syntax;
 #[macro_use]
 extern crate derive_more;
-extern crate regex;
 extern crate rls_span;
 
 #[macro_use]


### PR DESCRIPTION
In #879 I used regex for detect `const unsafe`, but it's not so fast so I replaced it with another implementation without regex.
Here's the results of `cargo bench completes`
Before:
```
running 3 tests
test completes_hashmap               ... bench:     698,525 ns/iter (+/- 61,262)
test completes_methods_for_file_open ... bench:     720,034 ns/iter (+/- 99,792)
test completes_methods_for_vec       ... bench: 102,333,066 ns/iter (+/- 8,533,846)
```

After:
```
test completes_hashmap               ... bench:     685,781 ns/iter (+/- 19,461)
test completes_methods_for_file_open ... bench:     637,061 ns/iter (+/- 42,679)
test completes_methods_for_vec       ... bench: 101,432,033 ns/iter (+/- 3,077,564)
```