### PR TITLE
Pass frozen=true flag to cargo by default to avoid network access

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,7 +54,7 @@ build: false
 # TODO modify this phase as you see fit
 test_script:
   - cargo build --verbose
-  - cargo test
+  - cargo test --features allow_net
 
 cache:
   - target

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_script:
   - export RUST_SRC_PATH=`rustc --print sysroot`/lib/rustlib/src/rust/src
 
 script:
-  - travis-cargo test
+  - travis-cargo test --features allow_net

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ rust:
 
 cache: cargo
 
-env:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=""
-
 before_script:
-  - pip install 'travis-cargo<0.2' --user
-  - export PATH=$HOME/.local/bin:$PATH
   - rustup component add rust-src
   - export RUST_SRC_PATH=`rustc --print sysroot`/lib/rustlib/src/rust/src
 
 script:
-  - travis-cargo test --features allow_net
+  - cargo build --features allow_net
+  - cargo test --features allow_net

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rls-span = "0.4.0"
 racer-testutils = { path = "testutils" }
 
 [features]
+allow_net = []
 nightly = []
 
 [workspace]

--- a/src/racer/fileres.rs
+++ b/src/racer/fileres.rs
@@ -1,6 +1,8 @@
-use cargo::core::{resolver::Method, Workspace};
+use cargo::core::{
+    registry::PackageRegistry, resolver::{EncodableResolve, Method, Resolve}, Workspace,
+};
 use cargo::ops;
-use cargo::util::important_paths::find_root_manifest_for_wd;
+use cargo::util::{errors::CargoResult, important_paths::find_root_manifest_for_wd, toml};
 use cargo::Config;
 use core::Session;
 use nameres::RUST_SRC_PATH;
@@ -88,16 +90,42 @@ fn get_outer_crates(libname: &str, from_path: &Path, session: &Session) -> Optio
 
 fn resolve_dependencies(manifest: &Path, session: &Session, libname: &str) -> Option<PathBuf> {
     let mut config = cargo_try!(Config::default());
-    // verbose=0, quiet=true, frozen=true, locked=true
-    config.configure(0, Some(true), &None, true, true, &None, &[]).ok()?;
+    let frozen = !cfg!(feature = "allow_net");
+    config.configure(0, Some(true), &None, frozen, true, &None, &[]).ok()?;
     let ws = cargo_try!(Workspace::new(&manifest, &config));
-    // resolve dependencies
-    let (packages, _) = cargo_try!(ops::resolve_ws_with_method(&ws, None, Method::Everything, &[]));
+    // get resolve from lock file
+    let lock_path = ws.root().to_owned().join("Cargo.lock");
+    let lock_file = session.load_lockfile(&lock_path, |lockfile| {
+        let resolve = cargo_try!(toml::parse(&lockfile, &lock_path, ws.config()));
+        let v: EncodableResolve = cargo_try!(resolve.try_into());
+        Some(cargo_try!(v.into_resolve(&ws)))
+    });
+    // then resolve precisely and add overrides
+    let mut registry = cargo_try!(PackageRegistry::new(ws.config()));
+    let resolve = cargo_try!(match lock_file {
+        Some(prev) => resolve_with_prev(&mut registry, &ws, Some(&*prev)),
+        None => resolve_with_prev(&mut registry, &ws, None),
+    });
+    add_overrides(&mut registry, &ws)
+        .unwrap_or_else(|e| warn!("[resolve_dependencies] error in add_override: {}", e));
+    // get depedency with overrides
+    let resolved_with_overrides = cargo_try!(ops::resolve_with_previous(
+        &mut registry,
+        &ws,
+        Method::Everything,
+        Some(&resolve),
+        None,
+        &[],
+        false,
+        false,
+    ));
+    let packages = get_resolved_packages(&resolved_with_overrides, registry);
+    let mut res = None;
+    // we have caches for each packages, so only need depth1 depedencies
     let depth1_dependencies = match ws.current_opt() {
         Some(cur) => cur.dependencies().iter().map(|p| p.name()).collect(),
         None => HashSet::new(),
     };
-    let mut res = None;
     let deps_map = packages
         .package_ids()
         .filter_map(|package_id| {
@@ -119,4 +147,54 @@ fn resolve_dependencies(manifest: &Path, session: &Session, libname: &str) -> Op
         .collect();
     session.cache_deps(manifest, deps_map);
     res
+}
+
+// wrapper of resolve_with_previous
+fn resolve_with_prev<'cfg>(
+    registry: &mut PackageRegistry<'cfg>,
+    ws: &Workspace<'cfg>,
+    prev: Option<&Resolve>,
+) -> CargoResult<Resolve> {
+    ops::resolve_with_previous(
+        registry,
+        ws,
+        Method::Everything,
+        prev,
+        None,
+        &[],
+        true,
+        false,
+    )
+}
+
+use cargo::core::{PackageSet, PackageId, Source, SourceId};
+use cargo::sources::PathSource;
+
+// until cargo 0.30 is released
+fn get_resolved_packages<'a>(resolve: &Resolve, registry: PackageRegistry<'a>) -> PackageSet<'a> {
+    let ids: Vec<PackageId> = resolve.iter().cloned().collect();
+    registry.get(&ids)
+}
+
+// until cargo 0.30 is released
+fn add_overrides<'a>(registry: &mut PackageRegistry<'a>, ws: &Workspace<'a>) -> CargoResult<()> {
+    let paths = match ws.config().get_list("paths")? {
+        Some(list) => list,
+        None => return Ok(()),
+    };
+
+    let paths = paths.val.iter().map(|&(ref s, ref p)| {
+        // The path listed next to the string is the config file in which the
+        // key was located, so we want to pop off the `.cargo/config` component
+        // to get the directory containing the `.cargo` folder.
+        (p.parent().unwrap().parent().unwrap().join(s), p)
+    });
+
+    for (path, _) in paths {
+        let id = SourceId::for_path(&path)?;
+        let mut source = PathSource::new_recursive(&path, &id, ws.config());
+        source.update()?;
+        registry.add_override(Box::new(source));
+    }
+    Ok(())
 }

--- a/test_project/test-crate3/Cargo.toml
+++ b/test_project/test-crate3/Cargo.toml
@@ -11,5 +11,5 @@ default-features = false
 features = []
 
 [patch.crates-io.rand]
-git = "https://github.com/rust-lang-nursery/rand.git"
+git = "https://github.com/rust-lang-nursery/rand"
 rev = "ea9fc2e5357dcf5d0497aa332cd0f8050017e3ec"

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3855,7 +3855,6 @@ println!("{}", m);
 [`Uniform`]: distributions/uniform/struct.Uniform.html"#;
     with_test_project(|dir| {
         let src_dir = dir.nested_dir("test-crate3").nested_dir("src");
-        println!("{:?}", src_dir);
         let got = get_only_completion(src, Some(src_dir));
         assert_eq!(got.matchstr, "gen_range");
         assert_eq!(got.docs, doc);


### PR DESCRIPTION
To prevent internet access.
Though sometimes it may be convenient if racer can download dependencies, I think racer should lightweight tool for now.