### PR TITLE
Enable completion for current package in examples/ or tests/ dir

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1204,7 +1204,6 @@ fn complete_from_file_(
                     &ImportInfo::default(),
                 )
             }
-            println!("{:?}", line);
             let path = if let Some(use_start) = scopes::use_stmt_start(line) {
                 scopes::construct_path_from_use_tree(&line[use_start.0..])
             } else {

--- a/test_project/src/lib.rs
+++ b/test_project/src/lib.rs
@@ -1,5 +1,20 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {}
+//! Root test_project for testing racer
+
+extern crate fixtures;
+extern crate test_crate2;
+
+pub use test_crate2::useless_func;
+
+pub struct TestStruct {
+    pub name: &'static str,
+    pub number: usize,
+}
+
+impl TestStruct {
+    pub fn new() -> Self {
+        TestStruct {
+            name: "test-struct",
+            number: 0,
+        }
+    }
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4092,3 +4092,20 @@ fn follows_complicated_use() {
     let got = get_all_completions(src, None);
     assert!(got.into_iter().any(|ma| ma.matchstr == "HashMap"));
 }
+
+
+#[test]
+fn get_completion_in_example_dir() {
+    let src = r"
+    extern crate test_project;
+    use test_project::TestStruct;
+    fn main() {
+        let test_struct = TestStruct::n~
+    }
+";
+    with_test_project(|dir| {
+        let example_dir = dir.nested_dir("examples");
+        let got = get_only_completion(src, Some(example_dir));
+        assert_eq!(got.matchstr, "new");
+    })
+}


### PR DESCRIPTION
For example, in racer/tests/system.rs, we become enable to get completions after
```rust
extern crate racer;
use racer::~
```
by this PR.
