### PR TITLE
Duplicate support for crates-io.patch

### DIFF
--- a/src/racer/fileres.rs
+++ b/src/racer/fileres.rs
@@ -1,5 +1,6 @@
 use cargo::core::{
-    registry::PackageRegistry, resolver::{EncodableResolve, Method, Resolve}, Workspace,
+    PackageSet, PackageId, registry::PackageRegistry,
+    resolver::{EncodableResolve, Method, Resolve}, Workspace
 };
 use cargo::ops;
 use cargo::util::{errors::CargoResult, important_paths::find_root_manifest_for_wd, toml};
@@ -106,20 +107,7 @@ fn resolve_dependencies(manifest: &Path, session: &Session, libname: &str) -> Op
         Some(prev) => resolve_with_prev(&mut registry, &ws, Some(&*prev)),
         None => resolve_with_prev(&mut registry, &ws, None),
     });
-    add_overrides(&mut registry, &ws)
-        .unwrap_or_else(|e| warn!("[resolve_dependencies] error in add_override: {}", e));
-    // get depedency with overrides
-    let resolved_with_overrides = cargo_try!(ops::resolve_with_previous(
-        &mut registry,
-        &ws,
-        Method::Everything,
-        Some(&resolve),
-        None,
-        &[],
-        false,
-        false,
-    ));
-    let packages = get_resolved_packages(&resolved_with_overrides, registry);
+    let packages = get_resolved_packages(&resolve, registry);
     let mut res = None;
     // we have caches for each crates, so only need depth1 depedencies(= dependencies in Cargo.toml)
     let depth1_dependencies = match ws.current_opt() {
@@ -177,34 +165,8 @@ fn resolve_with_prev<'cfg>(
     )
 }
 
-use cargo::core::{PackageSet, PackageId, Source, SourceId};
-use cargo::sources::PathSource;
-
 // until cargo 0.30 is released
 fn get_resolved_packages<'a>(resolve: &Resolve, registry: PackageRegistry<'a>) -> PackageSet<'a> {
     let ids: Vec<PackageId> = resolve.iter().cloned().collect();
     registry.get(&ids)
-}
-
-// until cargo 0.30 is released
-fn add_overrides<'a>(registry: &mut PackageRegistry<'a>, ws: &Workspace<'a>) -> CargoResult<()> {
-    let paths = match ws.config().get_list("paths")? {
-        Some(list) => list,
-        None => return Ok(()),
-    };
-
-    let paths = paths.val.iter().map(|&(ref s, ref p)| {
-        // The path listed next to the string is the config file in which the
-        // key was located, so we want to pop off the `.cargo/config` component
-        // to get the directory containing the `.cargo` folder.
-        (p.parent().unwrap().parent().unwrap().join(s), p)
-    });
-
-    for (path, _) in paths {
-        let id = SourceId::for_path(&path)?;
-        let mut source = PathSource::new_recursive(&path, &id, ws.config());
-        source.update()?;
-        registry.add_override(Box::new(source));
-    }
-    Ok(())
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3813,12 +3813,14 @@ fn follows_use_for_reexport() {
     })
 }
 
+// !!! this functionality is duplicated in #889
 // test for patch.crates-io
 // in test-crate3, we patches rand0.5.0 to
 // https://github.com/rust-lang-nursery/rand/commit/ea9fc2e5357dcf5d0497aa332cd0f8050017e3ec
 // , where doc for `gen_range` was modified, so if racer returns modified doc, it recognizes
 // patches.crates-io correctly
 #[test]
+#[ignore]
 fn check_work_with_cratesio_patch() {
     let src = "
     extern crate rand;


### PR DESCRIPTION
In #887, we prohibit racer to access internet, so now we can't get completion via `[crates-io.patch]` or other override sections in `Cargo.toml`.
But, in the future, if we come up with a good solution, let's support override again.