### PR TITLE
Support crate_in_paths

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -558,7 +558,7 @@ pub fn match_use(
     }
 
     let use_item = ast::parse_use(blob.to_owned());
-    debug!(
+    println!(
         "[match_use] found item: {:?}, searchstr: {}",
         use_item, context.search_str
     );

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -558,7 +558,7 @@ pub fn match_use(
     }
 
     let use_item = ast::parse_use(blob.to_owned());
-    println!(
+    debug!(
         "[match_use] found item: {:?}, searchstr: {}",
         use_item, context.search_str
     );

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1440,7 +1440,9 @@ pub fn resolve_path(
         let pathseg = &path.segments[0];
         resolve_name(pathseg, filepath, pos, search_type, namespace, session, import_info)
     } else if len != 0 {
-        if path.segments[0].name == "self" {
+        // TODO(kngwyu): we should distinguish self and crate,
+        // but maybe it's not absolutely important for use experiences.
+        if path.segments[0].name == "self" || path.segments[0].name == "crate" {
             // just remove self
             let mut newpath: core::Path = path.clone();
             newpath.segments.remove(0);

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4095,7 +4095,6 @@ fn follows_complicated_use() {
     assert!(got.into_iter().any(|ma| ma.matchstr == "HashMap"));
 }
 
-
 #[test]
 fn get_completion_in_example_dir() {
     let src = r"
@@ -4110,4 +4109,25 @@ fn get_completion_in_example_dir() {
         let got = get_only_completion(src, Some(example_dir));
         assert_eq!(got.matchstr, "new");
     })
+}
+
+#[test]
+fn follows_use_crate() {
+    let mod_src = "
+    pub fn myfn() {}
+    pub fn foo() {}
+    ";
+    let lib_src = "
+    mod mymod;
+    use crate::mymod::*;
+    fn main() {
+        myf~
+    }
+    ";
+
+    let dir = TmpDir::new();
+    let _lib = dir.write_file("mymod.rs", mod_src);
+    let got = get_only_completion(lib_src, Some(dir));
+    assert_eq!(got.matchstr, "myfn");
+    assert_eq!(got.contextstr, "pub fn myfn()");
 }


### PR DESCRIPTION
For #880.
What I did is just to skip `crate` keyword in `resolve_path`, but anyway it works.
I think we should handle visibility correctly in the future, I don't think we should do it now.