### PR TITLE
Fix getting context for finds_definition

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4166,7 +4166,7 @@ fn completes_static_method_for_typedef() {
 #[test]
 fn finds_definition_in_use_tree() {
     let src = "
-    pub use std::{collections::{hash_map::DefaultHa~sher,
+    pub use std::{collections::{HashMap, hash_map::DefaultHa~sher,
     ";
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "DefaultHasher");

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4161,3 +4161,13 @@ fn completes_static_method_for_typedef() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "append_elements");
 }
+
+// for #882
+#[test]
+fn finds_definition_in_use_tree() {
+    let src = "
+    pub use std::{collections::{hash_map::DefaultHa~sher,
+    ";
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "DefaultHasher");
+}


### PR DESCRIPTION
Now find_definition for nested path (e.g. finds `DefaultHasher` from
```rust
use std::{collections::{HashMap, hash_map::DefaultHasher}};
```
) doesn't work, so fixed it.
Related to #882, #886 