### PR TITLE
Add follows_std & follows_collections benchmark

### DIFF
--- a/benches/bench_stdlibs.rs
+++ b/benches/bench_stdlibs.rs
@@ -42,3 +42,25 @@ fn completes_methods_for_file_open(b: &mut Bencher) {
         var = get_all_completions(src, None);
     })
 }
+
+#[bench]
+fn follows_std(b: &mut Bencher) {
+    let src = r#"
+    use std::~
+"#;
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}
+
+#[bench]
+fn follows_collections(b: &mut Bencher) {
+    let src = r#"
+    use std::collections::~
+"#;
+    let mut var = vec![];
+    b.iter(|| {
+        var = get_all_completions(src, None);
+    })
+}


### PR DESCRIPTION
To bench the performance we get module or struct definitions.
Here's the result:
```
running 2 tests
test follows_collections             ... bench:  14,685,220 ns/iter (+/- 282,990)
test follows_std                     ... bench:  20,353,338 ns/iter (+/- 292,506)
```
(Core i5-6500, Arch Linux 4.17.5, rustc 1.29.0-nightly (e06c87544 2018-07-06))