### PR TITLE
Support macros in stdlibs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -727,6 +727,7 @@ dependencies = [
 name = "racer"
 version = "2.0.14"
 dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1038,8 +1039,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "socket2"
@@ -1406,7 +1410,7 @@ dependencies = [
 "checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 "checksum serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "84b8035cabe9b35878adec8ac5fe03d5f6bc97ff6edd7ccb96b44c1276ba390e"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
-"checksum smallvec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "312a7df010092e73d6bbaf141957e868d4f30efd2bfd9bb1028ad91abec58514"
+"checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
 "checksum socket2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "962a516af4d3a7c272cb3a1d50a8cc4e5b41802e4ad54cfb7bee8ba61d37d703"
 "checksum stable_deref_trait 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbc596e092fe5f598b12ef46cc03754085ac2f4d8c739ad61c4ae266cc3b3fa"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ doc = false
 debug = true
 
 [dependencies]
+bitflags = "1.0"
 cargo = "0.28"
 log = "0.4"
 rustc-ap-syntax = "184.0.0"

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -69,13 +69,32 @@ pub enum SearchType {
     StartsWith
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
-pub enum Namespace {
-    Type,
-    Value,
-    Both
+mod declare_namespace {
+    // (kngwyu) I reserved Crate, Mod or other names for future usage(like for #830)
+    // but, currently they're not used and... I'm not sure they're useful:)
+    #![allow(non_upper_case_globals, unused)]
+    bitflags!{
+        /// Type context
+        pub struct Namespace: u32 {
+            const Crate    = 0b0000000000001;
+            const Mod      = 0b0000000000010;
+            const Struct   = 0b0000000000100;
+            const Enum     = 0b0000000001000;
+            const Union    = 0b0000000010000;
+            const Trait    = 0b0000000100000;
+            const Type     = 0b0000001111111;
+            const Const    = 0b0000010000000;
+            const Static   = 0b0000100000000;
+            const Func     = 0b0001000000000;
+            const Macro    = 0b0010000000000;
+            const Value    = 0b0011110000000;
+            const Both     = 0b0011111111111;
+            // temporary hack (kngwyu)
+            const StdMacro = 0b0100000000000;
+        }
+    }
 }
+pub use self::declare_namespace::Namespace;
 
 #[derive(Debug, Clone, Copy)]
 pub enum CompletionType {
@@ -1259,7 +1278,7 @@ fn complete_from_file_(
                 filepath,
                 pos,
                 SearchType::StartsWith,
-                Namespace::Both,
+                Namespace::Both | Namespace::StdMacro,
                 session,
                 &ImportInfo::default(),
             ));
@@ -1397,7 +1416,7 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
                 filepath,
                 pos,
                 SearchType::ExactMatch,
-                Namespace::Both,
+                Namespace::Both | Namespace::StdMacro,
                 session,
                 &ImportInfo::default(),
             ).nth(0)

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -76,25 +76,26 @@ mod declare_namespace {
     bitflags!{
         /// Type context
         pub struct Namespace: u32 {
-            const Crate    = 0b0000000000001;
-            const Mod      = 0b0000000000010;
-            const Struct   = 0b0000000000100;
-            const Enum     = 0b0000000001000;
-            const Union    = 0b0000000010000;
-            const Trait    = 0b0000000100000;
-            const Type     = 0b0000001111111;
-            const Const    = 0b0000010000000;
-            const Static   = 0b0000100000000;
-            const Func     = 0b0001000000000;
-            const Macro    = 0b0010000000000;
-            const Value    = 0b0011110000000;
-            const Both     = 0b0011111111111;
-            // temporary hack (kngwyu)
-            const StdMacro = 0b0100000000000;
+            const Crate  = 0b0000000000001;
+            const Mod    = 0b0000000000010;
+            const Struct = 0b0000000000100;
+            const Enum   = 0b0000000001000;
+            const Union  = 0b0000000010000;
+            const Trait  = 0b0000000100000;
+            const Type   = 0b0000001111111;
+            const Const  = 0b0000010000000;
+            const Static = 0b0000100000000;
+            const Func   = 0b0001000000000;
+            const Value  = 0b0001110000000;
+            const Both   = 0b0001111111111;
+            // we don't include macro in `Value`
+            // see #902 for detail(kngwyu)
+            const Macro  = 0b0010000000000;
         }
     }
 }
 pub use self::declare_namespace::Namespace;
+
 
 #[derive(Debug, Clone, Copy)]
 pub enum CompletionType {
@@ -439,6 +440,10 @@ impl Path {
     pub fn extend(&mut self, path: Path) -> &mut Self {
         self.segments.extend(path.segments);
         self
+    }
+
+    pub fn len(&self) -> usize {
+        self.segments.len()
     }
 }
 
@@ -1261,8 +1266,9 @@ fn complete_from_file_(
                     &ImportInfo::default(),
                 )
             }
-            let path = if let Some(use_start) = scopes::use_stmt_start(line) {
-                scopes::construct_path_from_use_tree(&line[use_start.0..])
+            let (path, namespace) = if let Some(use_start) = scopes::use_stmt_start(line) {
+                let path = scopes::construct_path_from_use_tree(&line[use_start.0..]);
+                (path, Namespace::Both)
             } else {
                 let is_global = expr.starts_with("::");
                 let v: Vec<_> = (if is_global {
@@ -1270,7 +1276,13 @@ fn complete_from_file_(
                 } else {
                     expr
                 }).split("::").collect();
-                Path::from_vec(is_global, v)
+                let path = Path::from_vec(is_global, v);
+                let namespace = if path.len() == 1 {
+                    Namespace::Macro | Namespace::Both
+                } else {
+                    Namespace::Both
+                };
+                (path, namespace)
             };
             debug!("path: {:?}, is_global: {:?}", path, path.global);
             out.extend(nameres::resolve_path(
@@ -1278,7 +1290,7 @@ fn complete_from_file_(
                 filepath,
                 pos,
                 SearchType::StartsWith,
-                Namespace::Both | Namespace::StdMacro,
+                namespace,
                 session,
                 &ImportInfo::default(),
             ));
@@ -1399,8 +1411,9 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
     match completetype {
         CompletionType::Path => {
             let line = scopes::get_current_line(&src, range.end);
-            let path = if let Some(use_start) = scopes::use_stmt_start(line) {
-                scopes::construct_path_from_use_tree(&line[use_start.0..])
+            let (path, namespace) = if let Some(use_start) = scopes::use_stmt_start(line) {
+                let path = scopes::construct_path_from_use_tree(&line[use_start.0..]);
+                (path, Namespace::Both)
             } else {
                 let is_global = expr.starts_with("::");
                 let v: Vec<_> = (if is_global {
@@ -1408,7 +1421,13 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
                 } else {
                     expr
                 }).split("::").collect();
-                Path::from_vec(is_global, v)
+                let path = Path::from_vec(is_global, v);
+                let namespace = if path.len() == 1 {
+                    Namespace::Macro | Namespace::Both
+                } else {
+                    Namespace::Both
+                };
+                (path, namespace)
             };
             debug!("[find_definition_] Path: {:?}", path);
             nameres::resolve_path(
@@ -1416,7 +1435,7 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
                 filepath,
                 pos,
                 SearchType::ExactMatch,
-                Namespace::Both | Namespace::StdMacro,
+                namespace,
                 session,
                 &ImportInfo::default(),
             ).nth(0)

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -6,6 +6,8 @@
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate bitflags;
 
 extern crate cargo;
 extern crate syntax;

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -87,7 +87,6 @@ pub fn match_values(src: Src, context: &MatchCxt) -> impl Iterator<Item=Match> {
     match_const(&src, context).into_iter()
         .chain(match_static(&src, context))
         .chain(match_fn(&src, context))
-        .chain(match_macro(&src, context))
 }
 
 fn find_keyword(src: &str, pattern: &str, ignore: &[&str], context: &MatchCxt) -> Option<BytePos> {

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1136,33 +1136,19 @@ fn run_matchers_on_blob(
         namespace
     );
     let mut out = Vec::new();
-    match namespace {
-        Namespace::Type =>
-            for m in matchers::match_types(src, context, session, import_info) {
-                out.push(m);
-                if context.search_type == ExactMatch {
-                    return out;
-                }
-            },
-        Namespace::Value =>
-            for m in matchers::match_values(src, context) {
-                out.push(m);
-                if context.search_type == ExactMatch {
-                    return out;
-                }
-            },
-        Namespace::Both => {
-            for m in matchers::match_types(src, context, session, import_info) {
-                out.push(m);
-                if context.search_type == ExactMatch {
-                    return out;
-                }
+    if namespace.contains(Namespace::Type) {
+        for m in matchers::match_types(src, context, session, import_info) {
+            out.push(m);
+            if context.search_type == ExactMatch {
+                return out;
             }
-            for m in matchers::match_values(src, context) {
-                out.push(m);
-                if context.search_type == ExactMatch {
-                    return out;
-                }
+        }
+    }
+    if namespace.contains(Namespace::Value) {
+        for m in matchers::match_values(src, context) {
+            out.push(m);
+            if context.search_type == ExactMatch {
+                return out;
             }
         }
     }
@@ -1403,6 +1389,10 @@ pub fn resolve_name(
             out.push(m);
         }
     }
+
+    if namespace.contains(Namespace::StdMacro) {
+        get_std_macros(searchstr, search_type, session, &mut out);
+    }
     out.into_iter()
 }
 
@@ -1544,7 +1534,7 @@ pub fn resolve_path(
     filepath: &Path,
     pos: BytePos,
     search_type: SearchType,
-    namespace: Namespace,
+    mut namespace: Namespace,
     session: &Session,
     import_info: &ImportInfo,
 ) -> vec::IntoIter<Match> {
@@ -1554,6 +1544,7 @@ pub fn resolve_path(
         let pathseg = &path.segments[0];
         resolve_name(pathseg, filepath, pos, search_type, namespace, session, import_info)
     } else if len != 0 {
+        namespace.remove(Namespace::StdMacro);
         // TODO(kngwyu): we should distinguish self and crate,
         // but maybe it's not absolutely important for use experiences.
         if path.segments[0].name == "self" || path.segments[0].name == "crate" {
@@ -1990,4 +1981,75 @@ fn get_subpathsearch(pathsearch: &core::PathSearch) -> Option<core::PathSearch> 
                    })
                })
         })
+}
+
+
+fn get_std_macros(
+    searchstr: &str,
+    search_type: SearchType,
+    session: &Session,
+    out: &mut Vec<Match>,
+) {
+    let std_path = if let Some(ref p) = *RUST_SRC_PATH {
+        p
+    } else {
+        return;
+    };
+    let searchstr = if searchstr.ends_with("!") {
+        let len = searchstr.len();
+        &searchstr[..len - 1]
+    } else {
+        searchstr
+    };
+    let macro_path = std_path.join("libstd/macros.rs");
+    if !macro_path.exists() {
+        return;
+    }
+    let src = session.load_file(&macro_path);
+    let mut export = false;
+    out.extend(src.as_src()
+       .iter_stmts()
+       .filter_map(|range| {
+           let blob = &src[range.to_range()];
+           if blob.starts_with("#[macro_export]") {
+               export = true;
+               return None;
+           }
+           if !export {
+               return None;
+           }
+           if !blob.starts_with("macro_rules!") {
+               return None;
+           }
+           export = false;
+           let mut start = BytePos(12);
+           for &b in blob[start.0..].as_bytes() {
+               match b {
+                   b if util::is_whitespace_byte(b) => start = start.increment(),
+                   _ => break,
+               }
+           }
+           if !blob[start.0..].starts_with(searchstr) {
+               return None;
+           }
+           let end = find_ident_end(blob, start + BytePos(searchstr.len()));
+           let mut matchstr = blob[start.0..end.0].to_owned();
+           if search_type == SearchType::ExactMatch && searchstr != matchstr {
+               return None;
+           }
+           matchstr.push_str("!");
+           let point = range.start + start;
+           Some(Match {
+               matchstr,
+               filepath: macro_path.clone(),
+               point,
+               coords: src.point_to_coords(point),
+               local: false,
+               mtype: MatchType::Macro,
+               contextstr: matchers::first_line(blob),
+               generic_args: Vec::new(),
+               generic_types: Vec::new(),
+               docs: String::new(),
+           })
+       }));
 }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1152,6 +1152,11 @@ fn run_matchers_on_blob(
             }
         }
     }
+    if namespace.contains(Namespace::Macro) {
+        if let Some(m) = matchers::match_macro(&src, context) {
+            out.push(m);
+        }
+    }
     out
 }
 
@@ -1390,7 +1395,7 @@ pub fn resolve_name(
         }
     }
 
-    if namespace.contains(Namespace::StdMacro) {
+    if namespace.contains(Namespace::Macro) {
         get_std_macros(searchstr, search_type, session, &mut out);
     }
     out.into_iter()
@@ -1534,17 +1539,16 @@ pub fn resolve_path(
     filepath: &Path,
     pos: BytePos,
     search_type: SearchType,
-    mut namespace: Namespace,
+    namespace: Namespace,
     session: &Session,
     import_info: &ImportInfo,
 ) -> vec::IntoIter<Match> {
     debug!("resolve_path {:?} {:?} {:?} {:?}", path, filepath.display(), pos, search_type);
-    let len = path.segments.len();
+    let len = path.len();
     if len == 1 {
         let pathseg = &path.segments[0];
         resolve_name(pathseg, filepath, pos, search_type, namespace, session, import_info)
     } else if len != 0 {
-        namespace.remove(Namespace::StdMacro);
         // TODO(kngwyu): we should distinguish self and crate,
         // but maybe it's not absolutely important for use experiences.
         if path.segments[0].name == "self" || path.segments[0].name == "crate" {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4230,3 +4230,20 @@ fn finds_def_of_println() {
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "println!");
 }
+
+#[test]
+fn doesnt_complete_macro_after_use() {
+    let src = r#"
+    use printl~
+    "#;
+    let got = get_all_completions(src, None);
+    assert!(got.is_empty(), "got: {:?}", got);
+    let src = r#"
+    macro_rules! macro {
+        () => {}
+    }
+    use macr~
+    "#;
+    let got = get_all_completions(src, None);
+    assert!(got.is_empty(), "got: {:?}", got);
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4197,3 +4197,36 @@ fn finds_std_fn_in_extern_block() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "copy_nonoverlapping");
 }
+
+#[test]
+fn complets_println() {
+    let src = r#"
+    fn main() {
+        printl~
+    }
+    "#;
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "println!");
+}
+
+#[test]
+fn doesnt_complete_cfg_if() {
+    let src = r#"
+    fn main() {
+        cfg_i~
+    }
+    "#;
+    let got = get_all_completions(src, None);
+    assert!(got.is_empty(), "got: {:?}", got);
+}
+
+#[test]
+fn finds_def_of_println() {
+    let src = r#"
+    fn main() {
+        printl~n!("Hello@_@");
+    }
+    "#;
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "println!");
+}


### PR DESCRIPTION
By this PR we can get completions for `prinltn!` or other macros in stdlib.
This implementation is a bit hacky, ~~but since it's difficult to support macros in external crates(to do this, we have to parse too many files :sweat: ), I think it's enough.~~
(Edited: Now I feel we can use this approach for other macros, but not sure)
And, I want to let this the last PR before 2.1.