### PR TITLE
Fix Try operator support for Option & Result

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -703,21 +703,19 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
 
             ExprKind::Try(ref expr) => {                
                 self.visit_expr(&expr);
-                debug!("ExprTypeVisitor result: {:?} expr: {:?}", self.result, expr);
+                debug!("ExprKind::Try result: {:?} expr: {:?}", self.result, expr);
                 self.result = if let Some(&Ty::Match(ref m)) = self.result.as_ref() {
                     // HACK for speed up (kngwyu)
                     // Yeah there're many corner cases but it'll work well in most cases
                     if m.matchstr == "Result" || m.matchstr == "Option" {
-                        if let Some(ref ok_var) = m.generic_types.get(0) {
+                        m.generic_types.get(0).and_then(|ok_var| {
                             find_type_match(
                                 &ok_var.path,
                                 &ok_var.filepath,
                                 ok_var.point,
                                 self.session,
                             )
-                        } else {
-                            None
-                        }
+                        })
                     } else {
                         debug!("Unable to desugar Try expression; type was {} with arity {} of {}", 
                             m.matchstr, 

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -702,21 +702,22 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
             }
 
             ExprKind::Try(ref expr) => {                
-                debug!("try expr");
                 self.visit_expr(&expr);
+                debug!("ExprTypeVisitor result: {:?} expr: {:?}", self.result, expr);
                 self.result = if let Some(&Ty::Match(ref m)) = self.result.as_ref() {
-                    // HACK: Try to break open the result and find it's "Ok" type.
-                    // Once the 'Try' operator trait stabilizes, it'd be better to
-                    // find the type through the trait.
-                    if m.matchstr == "Result" && m.generic_types.len() == 2 {
-                        let ok_var = &m.generic_types[0];
-                        find_type_match(&ok_var.path, 
-                                        &ok_var.filepath, 
-                                        ok_var.point, 
-                                        self.session)
-                    } else if m.matchstr == "Result" && (m.generic_types.len() != m.generic_args.len()) {
-                        debug!("Unable to desugar Try expression; either `T` or `E` was `()`.");
-                        None
+                    // HACK for speed up (kngwyu)
+                    // Yeah there're many corner cases but it'll work well in most cases
+                    if m.matchstr == "Result" || m.matchstr == "Option" {
+                        if let Some(ref ok_var) = m.generic_types.get(0) {
+                            find_type_match(
+                                &ok_var.path,
+                                &ok_var.filepath,
+                                ok_var.point,
+                                self.session,
+                            )
+                        } else {
+                            None
+                        }
                     } else {
                         debug!("Unable to desugar Try expression; type was {} with arity {} of {}", 
                             m.matchstr, 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4305,3 +4305,32 @@ fn finds_local_macro_doc() {
     let doc = "my macro";
     assert_eq!(got.docs, doc);
 }
+
+#[test]
+fn let_try_socket() {
+    let src = r#"
+    use std::net::UdpSocket;
+    use std::io;
+    fn main() -> io::Result<()> {
+        let sock = UdpSocket::bind("127.0.0.1:1234")?;
+        sock.multicast_~
+    }
+"#;
+    let got = get_all_completions(src, None);
+    assert!(got.into_iter().any(|ma| ma.matchstr == "multicast_loop_v6"));
+}
+
+#[test]
+fn let_try_option() {
+    let src = r#"
+    fn f() -> Option<String> {
+        Some(String::new())
+    }
+    fn f2() -> Option<()> {
+        let s = f()?;
+        s.as_mut_v~
+    }
+"#;
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "as_mut_vec");
+}


### PR DESCRIPTION
For result: Modified to work even in case racer can't find `error` type
For option: Enabled to work

And, in addition, generic try trait support is important future work :slightly_smiling_face: 