### PR TITLE
Fix overflowing const/static matches (Fixes #746)

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -174,20 +174,22 @@ fn match_pattern_start(
 
     let blob = &src[context.range.to_range()];
     if let Some(start) = find_keyword(blob, pattern, ignore, context) {
-        if let Some(end) = blob[start.0..].find(':') {
-            let s = blob[start.0..start.0 + end].trim_right();
-            return Some(Match {
-                matchstr: s.to_owned(),
-                filepath: context.filepath.to_path_buf(),
-                point: context.range.start + start,
-                coords: None,
-                local: context.is_local,
-                mtype: mtype,
-                contextstr: first_line(blob),
-                generic_args: Vec::new(),
-                generic_types: Vec::new(),
-                docs: String::new(),
-            })
+        if let Some(end) = blob[start.0..].find(|c: char| c == ':' || c.is_whitespace()) {
+            if blob[start.0 + end..].trim_left().chars().next() == Some(':') {
+                let s = &blob[start.0..start.0 + end];
+                return Some(Match {
+                    matchstr: s.to_owned(),
+                    filepath: context.filepath.to_path_buf(),
+                    point: context.range.start + start,
+                    coords: None,
+                    local: context.is_local,
+                    mtype: mtype,
+                    contextstr: first_line(blob),
+                    generic_args: Vec::new(),
+                    generic_types: Vec::new(),
+                    docs: String::new(),
+                })
+            }
         }
     }
     None

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -156,7 +156,7 @@ fn find_keyword_impl(
 fn is_const_fn(src: &str, blob_range: ByteRange) -> bool {
     if let Some(b) = strip_word(&src[blob_range.to_range()], "const") {
         let s = src[(blob_range.start + b).0..].trim_left();
-        !s.starts_with("fn") && !s.starts_with("unsafe")
+        s.starts_with("fn") || s.starts_with("unsafe")
     } else {
         false
     }


### PR DESCRIPTION
This fixes behaviour where the match string returned for ``static`` and ``pub const`` (regular ``const`` would trigger this too, but ``is_const_fn`` is broken and stops this as a side-effect) variables and functions will include all characters after the variable name up to the first occurrence of ``':'``. This can be triggered by const declarations with whitespace before the ``':'`` and by certain function declarations such as ``std::Vec::new()``.

Fixes #746