### PR TITLE
Fix completion for 'for x in ..'

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1280,7 +1280,8 @@ pub fn find_definition_(
                         searchstr,
                         SearchType::ExactMatch,
                         session,
-                    ).filter(|m| m.mtype == match_type)
+                    ).into_iter()
+                    .filter(|m| m.mtype == match_type)
                     .nth(0)
                 } else {
                     None

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -240,7 +240,7 @@ fn match_pattern_let(
                     coords: None,
                     local: context.is_local,
                     mtype: mtype.clone(),
-                    contextstr: first_line(blob),
+                    contextstr: blob.to_owned(),
                     docs: String::new(),
                 });
                 if context.search_type == ExactMatch {
@@ -280,7 +280,7 @@ pub fn match_for(msrc: &str, context: &MatchCxt) -> Vec<Match> {
                 coords: None,
                 local: context.is_local,
                 mtype: For,
-                contextstr: first_line(blob),
+                contextstr: blob.to_owned(),
                 docs: String::new(),
             });
         }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -112,7 +112,6 @@ pub fn search_for_impl_methods(
                     match_request,
                     &header,
                     fieldsearchstr,
-                    fpath,
                     session,
                 ));
             }
@@ -345,7 +344,6 @@ fn impl_scope_start(blob: &str) -> Option<usize> {
     None
 }
 
-// this function shouldn't be looked from outer
 // get impl headers from scope
 fn search_for_impls(
     pos: BytePos,
@@ -386,6 +384,66 @@ fn search_for_impls(
                 .map_or(false, |name| symbol_matches(ExactMatch, searchstr, name));
             if matched {
                 out.push(impl_header);
+            }
+        }
+    }
+    out
+}
+
+// trait_only version of search_for_impls
+// needs both `Self` type name and trait name
+fn search_trait_impls(
+    pos: BytePos,
+    self_search: &str,
+    trait_search: &str,
+    once: bool,
+    filepath: &Path,
+    local: bool,
+    session: &Session,
+) -> Vec<ImplHeader> {
+    debug!(
+        "search_trait_impls {:?}, {}, {}, {:?}",
+        pos,
+        self_search,
+        trait_search,
+        filepath.display()
+    );
+    let s = session.load_source_file(filepath);
+    let scope_start = scopes::scope_start(s.as_src(), pos);
+    let src = s.get_src_from_start(scope_start);
+
+    let mut out = Vec::new();
+    for blob_range in src.iter_stmts() {
+        let blob = &src[blob_range.to_range()];
+        if let Some(n) = impl_scope_start(blob) {
+            if !txt_matches(ExactMatch, self_search, &blob[..n + 1]) {
+                continue;
+            }
+            let decl = blob[..n + 1].to_owned() + "}";
+            let start = blob_range.start + scope_start;
+            let impl_header = try_continue!(ast::parse_impl(
+                decl,
+                filepath,
+                blob_range.start + scope_start,
+                local,
+                start + n.into(),
+            ));
+            let self_matched = impl_header
+                .self_path()
+                .name()
+                .map_or(false, |name| symbol_matches(ExactMatch, self_search, name));
+            if !self_matched {
+                continue;
+            }
+            let trait_matched = impl_header
+                .trait_path()
+                .and_then(|tpath| Some(symbol_matches(ExactMatch, trait_search, tpath.name()?)))
+                .unwrap_or(false);
+            if trait_matched {
+                out.push(impl_header);
+                if once {
+                    break;
+                }
             }
         }
     }
@@ -2043,7 +2101,7 @@ pub fn search_for_field_or_method(
     searchstr: &str,
     search_type: SearchType,
     session: &Session,
-) -> vec::IntoIter<Match> {
+) -> Vec<Match> {
     let m = context;
     let mut out = Vec::new();
     // for Trait and TypeParameter
@@ -2130,7 +2188,7 @@ pub fn search_for_field_or_method(
             );
         }
     };
-    out.into_iter()
+    out
 }
 
 fn search_for_deref_matches(
@@ -2138,10 +2196,22 @@ fn search_for_deref_matches(
     type_match: &Match,      // the type which implements Deref
     impl_header: &ImplHeader,
     fieldsearchstr: &str,
-    fpath: &Path,
     session: &Session,
 ) -> Vec<Match> {
-    let mut out = Vec::new();
+    get_assoc_type_from_header(target_path, type_match, impl_header, session).map_or_else(
+        Vec::new,
+        |ty_match| {
+            search_for_field_or_method(ty_match, fieldsearchstr, SearchType::StartsWith, session)
+        },
+    )
+}
+
+fn get_assoc_type_from_header(
+    target_path: &RacerPath, // target = ~
+    type_match: &Match,      // the type which implements Deref
+    impl_header: &ImplHeader,
+    session: &Session,
+) -> Option<Match> {
     debug!(
         "[search_for_deref_matches] target: {:?} impl: {:?}",
         target_path, impl_header
@@ -2149,39 +2219,26 @@ fn search_for_deref_matches(
     if let Some((pos, _)) = impl_header.generics().search_param_by_path(target_path) {
         if let Some(path_search) = type_match.resolved_generics().nth(pos) {
             // TODO(kngwyu): does it work for nested generics?
-            if let Some(type_match) = resolve_path_with_str(
+            return resolve_path_with_str(
                 &path_search.path,
                 &path_search.filepath,
                 BytePos::ZERO,
                 SearchType::ExactMatch,
                 Namespace::Type,
                 session,
-            ).nth(0)
-            {
-                out.extend(search_for_field_or_method(
-                    type_match,
-                    fieldsearchstr,
-                    SearchType::StartsWith,
-                    session,
-                ));
-            }
+            ).nth(0);
         }
     } else {
-        let type_match = resolve_path_with_str(
+        return resolve_path_with_str(
             &target_path,
-            fpath,
+            impl_header.file_path(),
             BytePos::ZERO,
             SearchType::ExactMatch,
             Namespace::Type,
             session,
         ).nth(0);
-        if let Some(m) = type_match {
-            let methods =
-                search_for_field_or_method(m, fieldsearchstr, SearchType::StartsWith, session);
-            out.extend(methods);
-        }
     }
-    out
+    None
 }
 
 fn get_std_macros(
@@ -2300,4 +2357,26 @@ fn get_std_macros_(
             })
         }));
     }
+}
+
+pub(crate) fn get_intoiter_target(selfm: &Match, session: &Session) -> Option<Match> {
+    let into_iter_header = search_trait_impls(
+        selfm.point,
+        &selfm.matchstr,
+        "IntoIterator",
+        true,
+        &selfm.filepath,
+        selfm.local,
+        session,
+    ).into_iter()
+    .next()?;
+    let item = search_scope_for_impled_assoc_types(
+        &into_iter_header,
+        "Item",
+        core::SearchType::ExactMatch,
+        session,
+    );
+    item.get(0).and_then(|(_, item_path)| {
+        get_assoc_type_from_header(item_path, selfm, &into_iter_header, session)
+    })
 }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -573,7 +573,6 @@ fn search_scope_headers(
             }
         } else if preblock.starts_with("for ") {
             let src = msrc[stmtstart.0..scopestart.0].trim().to_owned() + "{}";
-            println!("{:?}", src);
             if txt_matches(search_type, search_str, &msrc[..scopestart.0]) {
                 let match_cxt = get_cxt(src.len());
                 let mut out = matchers::match_for(&src, &match_cxt);

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -251,7 +251,7 @@ fn get_type_of_for_arg(m: &Match, msrc: Src, session: &Session) -> Option<Ty> {
         warn!("[get_type_of_for_expr] invalid match type: {:?}", m.mtype);
         return None;
     }
-    debug!("[get_type_of_for_expr] match: {:?}", m);
+    println!("[get_type_of_for_expr] match: {:?}", m);
     let res = ast::parse_for_stmt(m.contextstr.clone(), Scope::from_match(m), session);
     let for_pat = res.for_pat?;
     println!("{:?}", for_pat);

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -1,13 +1,13 @@
 //! Type inference
 //! THIS MODULE IS ENTIRELY TOO UGLY SO REALLY NEADS REFACTORING(kngwyu)
 use ast;
-use ast_types::Ty;
+use ast_types::{Pattern, Ty};
 use core;
 use core::Namespace;
 use core::SearchType::ExactMatch;
 use core::{BytePos, MaskedSource, Match, Scope, Session, SessionExt, Src};
 use matchers;
-use nameres::resolve_path_with_str;
+use nameres;
 use scopes;
 use std::path::Path;
 use util::{self, txt_matches};
@@ -114,7 +114,7 @@ pub fn get_type_of_self(
     if decl.starts_with("impl") {
         let implres = ast::parse_impl(decl, filepath, start, local, start)?;
         debug!("get_type_of_self_arg implres |{:?}|", implres);
-        resolve_path_with_str(
+        nameres::resolve_path_with_str(
             implres.self_path(),
             filepath,
             start,
@@ -246,53 +246,35 @@ fn get_type_of_let_block_expr(m: &Match, msrc: Src, session: &Session, prefix: &
     }
 }
 
-// TODO: it's inefficient(kngwyu)
-fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<Ty> {
-    let stmtstart = scopes::expect_stmt_start(msrc, m.point);
-    let stmt = msrc.shift_start(stmtstart);
-    let forpos = stmt
-        .find("for ")
-        .expect("`for` should appear in for .. in loop");
-    let inpos = stmt
-        .find(" in ")
-        .expect("`in` should appear in for .. in loop");
-    // XXX: this need not be the correct brace, see generate_skeleton_for_parsing
-    let bracepos = stmt
-        .find('{')
-        .expect("for-loop should have an opening brace");
-    let mut src = stmt[..forpos].to_owned();
-    src.push_str("if let Some(");
-    src.push_str(&stmt[forpos + 4..inpos]);
-    src.push_str(") = ");
-    let iter_stmt = &stmt[inpos + 4..bracepos];
-
-    // TODO: Remove these lines when iter()/iter_mut() method lookup on
-    //       built in types is properly supported
-    let mut iter_stmt_trimmed = iter_stmt.replace(".iter()", ".into_iter()");
-    iter_stmt_trimmed = iter_stmt_trimmed.replace(".iter_mut()", ".into_iter()");
-
-    src.push_str(&iter_stmt_trimmed);
-    src = src.trim_right().to_owned();
-    src.push_str(".into_iter().next() { }}");
-
-    let src = MaskedSource::new(&src);
-
-    if let Some(range) = src.as_src().iter_stmts().next() {
-        let blob = &src[range.to_range()];
-        debug!(
-            "get_type_of_for_expr: |{}| {:?} {:?} {} {:?}",
-            blob, m.point, stmtstart, forpos, range.start
-        );
-
-        let pos = m.point + BytePos(8) - stmtstart - forpos.into() - range.start;
-        let scope = Scope {
-            filepath: m.filepath.clone(),
-            point: stmtstart,
-        };
-        ast::get_let_type(blob.to_owned(), pos, scope, session)
-    } else {
-        None
+fn get_type_of_for_arg(m: &Match, msrc: Src, session: &Session) -> Option<Ty> {
+    if m.mtype != core::MatchType::For {
+        warn!("[get_type_of_for_expr] invalid match type: {:?}", m.mtype);
+        return None;
     }
+    debug!("[get_type_of_for_expr] match: {:?}", m);
+    let res = ast::parse_for_stmt(m.contextstr.clone(), Scope::from_match(m), session);
+    let for_pat = res.for_pat?;
+    println!("{:?}", for_pat);
+    match for_pat {
+        Pattern::Ident(bi, name) => if name == m.matchstr {
+            if let Ty::Match(ma) = res.in_expr? {
+                return nameres::get_intoiter_target(&ma, session).map(Ty::Match);
+            }
+        },
+        Pattern::Tuple(pats) => {}
+        Pattern::Ref(pat, _) => {}
+        Pattern::Struct(path, pats) => {}
+        Pattern::TupleStruct(path, pats) => {}
+        _ => {
+            debug!("[get_type_of_for_expr] unsupported pattern: {:?}", for_pat);
+        }
+    }
+    // let gen_impl =
+    //     nameres::search_for_trait_impls(BytePos::ZERO, "IntoIterator", &in_expr, true, session);
+    // for m in gen_impl {
+    //     println!("{} {:?}", m.matchstr, m.mtype);
+    // }
+    None
 }
 
 pub fn get_struct_field_type(
@@ -375,7 +357,7 @@ pub fn get_type_of_match(m: Match, msrc: Src, session: &Session) -> Option<Ty> {
         core::MatchType::Let => get_type_of_let_expr(&m, msrc, session),
         core::MatchType::IfLet => get_type_of_let_block_expr(&m, msrc, session, "if let"),
         core::MatchType::WhileLet => get_type_of_let_block_expr(&m, msrc, session, "while let"),
-        core::MatchType::For => get_type_of_for_expr(&m, msrc, session),
+        core::MatchType::For => get_type_of_for_arg(&m, msrc, session),
         core::MatchType::FnArg => get_type_of_fnarg(&m, msrc, session),
         core::MatchType::MatchArm => get_type_from_match_arm(&m, msrc, session),
         core::MatchType::Struct(_)

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4396,3 +4396,31 @@ fn completes_trait_method_only_once() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "function");
 }
+
+#[test]
+fn completes_methods_for_for_arg() {
+    let src = "
+    fn main() {
+        let v: Vec<String> = vec![];
+        for s in v {
+            s.ca~
+        }
+    }
+    ";
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "capacity");
+}
+
+#[test]
+fn completes_methods_for_tupled_for_arg() {
+    let src = "
+    fn main() {
+        let v: Vec<(String, usize)> = vec![];
+        for (s, i) in v {
+            s.ca~
+        }
+    }
+    ";
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "capacity");
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -233,42 +233,7 @@ fn completes_via_parent_scope_let() {
 
 #[test]
 fn completes_for_vec_field_and_method() {
-    let modsrc = "
-    pub trait IntoIterator {
-        type Item;
-
-        type IntoIter: Iterator<Item=Self::Item>;
-
-        fn into_iter(self) -> Self::IntoIter;
-    }
-
-    impl<T> IntoIterator for Vec<T> {
-        type Item = T;
-        type IntoIter = IntoIter<T>;
-
-        fn into_iter(mut self) -> IntoIter<T> {}
-    }
-
-    pub struct IntoIter<T> {}
-
-    impl<T> Iterator for IntoIter<T> {
-        type Item = T;
-
-        fn next(&mut self) -> Option<T> {}
-    }
-
-    pub struct Vec<T> {}
-
-    pub enum Option<T> {
-        None,
-        Some(T)
-    }
-    ";
     let src = "
-    pub mod mymod;
-    use mymod::{Vec, IntoIter, IntoIterator, Option};
-    use Option::{Some, None};
-
     struct St
     {
         stfield: i32,
@@ -292,17 +257,14 @@ fn completes_for_vec_field_and_method() {
     ";
 
     let dir = TmpDir::new();
-    let _mymod = dir.write_file("mymod.rs", modsrc);
     let path = dir.write_file("src.rs", src);
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
-    let cursor1 = Coordinate::new(22, 18);
+    let cursor1 = Coordinate::new(18, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
-    println!("{:?}", got1);
     assert_eq!("stfield", got1.matchstr);
-    let cursor2 = Coordinate::new(23, 18);
+    let cursor2 = Coordinate::new(19, 18);
     let got2 = complete_from_file(&path, cursor2, &session).nth(0).unwrap();
-    println!("{:?}", got2);
     assert_eq!("stmethod", got2.matchstr);
 }
 
@@ -441,48 +403,8 @@ fn completes_trait_bounded_methods_generic_return() {
 }
 
 #[test]
-fn completes_iter_variable_methods() {
-    let modsrc = "
-    pub trait Iterator {
-        type Item;
-
-        fn next(&mut self) -> Option<Self::Item>;
-    }
-
-    pub trait IntoIterator {
-        type Item;
-
-        type IntoIter: Iterator<Item=Self::Item>;
-
-        fn into_iter(self) -> Self::IntoIter;
-    }
-
-    impl<I: Iterator> IntoIterator for I {
-        type Item = I::Item;
-        type IntoIter = I;
-
-        fn into_iter(self) -> I {
-            self
-        }
-    }
-
-    impl<T> Iterator for IntoIter<T> {
-        type Item = T;
-
-        fn next(&mut self) -> Option<T> {}
-    }
-
-    pub enum Option<T> {
-        None,
-        Some(T)
-    }
-    ";
-
+fn completes_iter_variable_fiedlds() {
     let src = "
-    pub mod mymod;
-    use mymod::{Iterator, Option};
-    use Option::{Some, None};
-
     struct St {
         pub item: StItem,
         pub used: bool
@@ -493,7 +415,7 @@ fn completes_iter_variable_methods() {
     }
 
     impl Iterator for St {
-        type Item: StItem;
+        type Item = StItem;
 
         fn next(&mut self) -> Option<StItem> {
             if self.used {
@@ -516,61 +438,13 @@ fn completes_iter_variable_methods() {
         }
     }
     ";
-
-    let dir = TmpDir::new();
-    let _mymod = dir.write_file("mymod.rs", modsrc);
-    let got = get_one_completion(src, Some(dir));
+    let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "field");
 }
 
 #[test]
+#[ignore]
 fn completes_for_vec_iter_field_and_method() {
-    let modsrc = "
-    pub trait Iterator {
-        type Item;
-
-        fn next(&mut self) -> Option<Self::Item>;
-    }
-
-    pub trait IntoIterator {
-        type Item;
-
-        type IntoIter: Iterator<Item=Self::Item>;
-
-        fn into_iter(self) -> Self::IntoIter;
-    }
-
-    impl<T> IntoIterator for Vec<T> {
-        type Item = T;
-        type IntoIter = IntoIter<T>;
-
-        fn into_iter(mut self) -> IntoIter<T> {}
-    }
-
-    pub struct IntoIter<T> {}
-
-    impl<T> Iterator for IntoIter<T> {
-        type Item = T;
-
-        fn next(&mut self) -> Option<T> {}
-    }
-
-    impl<I: Iterator> IntoIterator for I {
-        type Item = I::Item;
-        type IntoIter = I;
-
-        fn into_iter(self) -> I {
-            self
-        }
-    }
-
-    pub struct Vec<T> {}
-
-    pub enum Option<T> {
-        None,
-        Some(T)
-    }
-    ";
     let src = "
     pub mod mymod;
     use mymod::{Vec, IntoIter, IntoIterator, Option};
@@ -597,19 +471,15 @@ fn completes_for_vec_iter_field_and_method() {
         }
     }
     ";
-
     let dir = TmpDir::new();
-    let _mymod = dir.write_file("mymod.rs", modsrc);
     let path = dir.write_file("src.rs", src);
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
     let cursor1 = Coordinate::new(22, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
-    println!("{:?}", got1);
     assert_eq!("stfield", got1.matchstr);
     let cursor2 = Coordinate::new(23, 18);
     let got2 = complete_from_file(&path, cursor2, &session).nth(0).unwrap();
-    println!("{:?}", got2);
     assert_eq!("stmethod", got2.matchstr);
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4282,12 +4282,44 @@ fn completes_methods_for_for_arg() {
 }
 
 #[test]
+#[ignore]
 fn completes_methods_for_tupled_for_arg() {
     let src = "
     fn main() {
         let v: Vec<(String, usize)> = vec![];
         for (s, i) in v {
             s.ca~
+        }
+    }
+    ";
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "capacity");
+}
+
+#[test]
+#[ignore]
+fn completes_methods_for_ref_for_arg() {
+    let src = "
+    fn main() {
+        let v: Vec<&String> = vec![];
+        for &s in v {
+            s.ca~
+        }
+    }
+    ";
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "capacity");
+}
+
+#[test]
+#[ignore]
+fn completes_methods_for_tupls_for_arg() {
+    let src = "
+    fn main() {
+        struct St(String);
+        let v: Vec<St> = vec![];
+        for St(s) in &v {
+            s.cap~
         }
     }
     ";


### PR DESCRIPTION
Enable completion for cases like
```rust
let v: Vec<String> = ..;
for x in v {
    x.~
}
```
.
Current implementation(see https://github.com/racer-rust/racer/blob/1a38903e2640d0cac735f918a858c3596f0222dc/src/racer/typeinf.rs#L250
)
is very inefficient and can't work without manually written `IntoIterator` implementation(i.e. it's useless in 99% cases).