### PR TITLE
if-let completion

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -247,8 +247,10 @@ fn destructure_pattern_to_ty(
             Ty::Tuple(ref typeelems) => {
                 let mut res = None;
                 for (i, p) in tuple_elements.iter().enumerate() {
-                    if point_is_in_span(point, &p.span) {
-                        let ty = &typeelems[i];
+                    if !point_is_in_span(point, &p.span) {
+                        continue;
+                    }
+                    if let Some(ref ty) = typeelems[i] {
                         res = destructure_pattern_to_ty(p, point, ty, scope, session);
                         break;
                     }
@@ -694,13 +696,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                 let mut v = Vec::new();
                 for expr in exprs {
                     self.visit_expr(expr);
-                    match self.result {
-                        Some(ref t) => v.push(t.clone()),
-                        None => {
-                            self.result = None;
-                            return;
-                        }
-                    };
+                    v.push(self.result.take());
                 }
                 self.result = Some(Ty::Tuple(v));
             }

--- a/src/racer/ast_types.rs
+++ b/src/racer/ast_types.rs
@@ -166,18 +166,6 @@ pub enum Pat {
 }
 
 impl Pat {
-    pub(crate) fn has_type(&self) -> bool {
-        match self {
-            Pat::Struct(..)
-            | Pat::TupleStruct(..)
-            | Pat::Path(_)
-            | Pat::Slice
-            | Pat::Lit
-            | Pat::Box => true,
-            Pat::Ref(pat, _) => pat.has_type(),
-            _ => false,
-        }
-    }
     pub fn from_ast(pat: &PatKind, scope: &Scope) -> Self {
         match pat {
             PatKind::Wild => Pat::Wild,

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "nightly", feature(test))]
-#![feature(fnbox, try_trait)]
+#![feature(nll, try_trait)]
 
 #[macro_use]
 extern crate log;

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -655,7 +655,7 @@ pub fn match_use(
                 search_path
                     .segments
                     .push(PathSegment::new(context.search_str.to_owned(), vec![]));
-                let mut path_iter = resolve_path(
+                let path_iter = resolve_path(
                     &search_path,
                     context.filepath,
                     context.range.start,

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -523,7 +523,7 @@ fn search_scope_headers(
         if txt_matches(search_type, search_str, trimed) {
             let src = trimed.to_owned() + "{}";
             let match_cxt = get_cxt(src.len());
-            let mut out = matchers::match_if_let(&src, &match_cxt);
+            let mut out = matchers::match_if_let(&src, ifletstart, &match_cxt);
             for m in &mut out {
                 m.point += ifletstart;
             }
@@ -534,7 +534,7 @@ fn search_scope_headers(
         if txt_matches(search_type, search_str, trimed) {
             let src = trimed.to_owned() + "{}";
             let match_cxt = get_cxt(src.len());
-            let mut out = matchers::match_while_let(&src, &match_cxt);
+            let mut out = matchers::match_while_let(&src, stmtstart, &match_cxt);
             for m in &mut out {
                 m.point += stmtstart;
             }
@@ -545,7 +545,7 @@ fn search_scope_headers(
         if txt_matches(search_type, search_str, trimed) {
             let src = trimed.to_owned() + "{}";
             let match_cxt = get_cxt(src.len());
-            let mut out = matchers::match_for(&src, &match_cxt);
+            let mut out = matchers::match_for(&src, stmtstart, &match_cxt);
             for m in &mut out {
                 m.point += stmtstart;
             }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -3,13 +3,12 @@
 use ast;
 use ast_types::{Pat, Ty};
 use core;
-use core::Namespace;
-use core::SearchType::ExactMatch;
-use core::{BytePos, MaskedSource, Match, Scope, Session, SessionExt, Src};
+use core::{
+    BytePos, MaskedSource, Match, MatchType, Namespace, Scope, SearchType, Session, SessionExt, Src,
+};
 use matchers;
 use nameres;
 use scopes;
-use std::boxed::FnBox;
 use std::path::Path;
 use util::{self, txt_matches};
 
@@ -71,7 +70,7 @@ pub fn first_param_is_self(blob: &str) -> bool {
             if let Some(start) = blob[skip_generic..].find('(') {
                 let start = BytePos::from(start).increment();
                 let end = scopes::find_closing_paren(blob, start);
-                let is_self = txt_matches(ExactMatch, "self", &blob[start.0..end.0]);
+                let is_self = txt_matches(SearchType::ExactMatch, "self", &blob[start.0..end.0]);
                 trace!(
                     "searching fn args for self: |{}| {}",
                     &blob[start.0..end.0],
@@ -127,13 +126,13 @@ pub fn get_type_of_self(
             implres.self_path(),
             filepath,
             start,
-            ExactMatch,
+            SearchType::ExactMatch,
             Namespace::Type,
             session,
         ).nth(0)
         .map(|mut m| {
             match &mut m.mtype {
-                core::MatchType::Enum(gen) | core::MatchType::Struct(gen) => {
+                MatchType::Enum(gen) | MatchType::Struct(gen) => {
                     for (i, param) in implres.generics.0.into_iter().enumerate() {
                         gen.add_bound(i, param.bounds);
                     }
@@ -268,7 +267,7 @@ fn get_type_of_let_block_expr(m: &Match, msrc: Src, session: &Session, prefix: &
 /// Decide l_value's type given r_value and ident query
 fn resolve_lvalue_ty<'a>(
     l_value: Pat,
-    r_value: Box<dyn 'a + FnBox() -> Option<Ty>>,
+    r_value: Option<Ty>,
     query: &str,
     fpath: &Path,
     pos: BytePos,
@@ -279,62 +278,66 @@ fn resolve_lvalue_ty<'a>(
             if name != query {
                 return None;
             }
-            r_value()
+            r_value
         }
         Pat::Tuple(pats) => {
-            if let Ty::Tuple(ty) = r_value()? {
+            if let Ty::Tuple(ty) = r_value? {
                 for (p, t) in pats.into_iter().zip(ty) {
-                    let ret = try_continue!(resolve_lvalue_ty(
-                        p,
-                        Box::new(move || Some(t)),
-                        query,
-                        fpath,
-                        pos,
-                        session,
-                    ));
+                    let ret =
+                        try_continue!(resolve_lvalue_ty(p, Some(t), query, fpath, pos, session,));
                     return Some(ret);
                 }
             }
             None
         }
         Pat::Ref(pat, _) => {
-            if let Some(ty) = r_value() {
+            if let Some(ty) = r_value {
                 if let Ty::RefPtr(ty) = ty {
-                    resolve_lvalue_ty(
-                        *pat,
-                        Box::new(move || Some(*ty)),
-                        query,
-                        fpath,
-                        pos,
-                        session,
-                    )
+                    resolve_lvalue_ty(*pat, Some(*ty), query, fpath, pos, session)
                 } else {
-                    resolve_lvalue_ty(*pat, Box::new(move || Some(ty)), query, fpath, pos, session)
+                    resolve_lvalue_ty(*pat, Some(ty), query, fpath, pos, session)
                 }
             } else {
-                resolve_lvalue_ty(*pat, Box::new(move || None), query, fpath, pos, session)
+                resolve_lvalue_ty(*pat, None, query, fpath, pos, session)
             }
         }
         Pat::TupleStruct(path, pats) => {
-            let item = ast::find_type_match(&path, fpath, pos, session)?;
-            if !item.mtype.is_struct() {
-                return None;
+            let mut ma = ast::find_type_match(&path, fpath, pos, session)?;
+            match &ma.mtype {
+                MatchType::Struct(_generics) => {
+                    for (pat, (_, _, t)) in
+                        pats.into_iter().zip(get_tuplestruct_fields_(&ma, session))
+                    {
+                        let ret =
+                            try_continue!(resolve_lvalue_ty(pat, t, query, fpath, pos, session));
+                        return Some(ret);
+                    }
+                    None
+                }
+                MatchType::EnumVariant(enum_) => {
+                    let generics = if let Some(Ty::Match(match_)) = r_value.map(Ty::dereference) {
+                        match_.into_generics()
+                    } else {
+                        enum_.to_owned().and_then(|ma| ma.into_generics())
+                    };
+                    for (pat, (_, _, mut t)) in
+                        pats.into_iter().zip(get_tuplestruct_fields_(&ma, session))
+                    {
+                        debug!(
+                            "Hi! I'm in enum and l: {:?}\n  r: {:?}\n gen: {:?}",
+                            pat, t, generics
+                        );
+                        if let Some(ref gen) = generics {
+                            t = t.map(|ty| ty.replace_by_generics(&gen));
+                        }
+                        let ret =
+                            try_continue!(resolve_lvalue_ty(pat, t, query, fpath, pos, session));
+                        return Some(ret);
+                    }
+                    None
+                }
+                _ => None,
             }
-            for (pat, (_, _, t)) in pats
-                .into_iter()
-                .zip(get_tuplestruct_fields_(&item, session))
-            {
-                let ret = try_continue!(resolve_lvalue_ty(
-                    pat,
-                    Box::new(move || t),
-                    query,
-                    fpath,
-                    pos,
-                    session
-                ));
-                return Some(ret);
-            }
-            None
         }
         // Let's implement after #946 solved
         Pat::Struct(path, _) => {
@@ -349,13 +352,18 @@ fn resolve_lvalue_ty<'a>(
 }
 
 fn get_type_of_for_arg(m: &Match, session: &Session) -> Option<Ty> {
-    if m.mtype != core::MatchType::For {
-        warn!("[get_type_of_for_expr] invalid match type: {:?}", m.mtype);
-        return None;
-    }
+    let for_start = match &m.mtype {
+        MatchType::For(pos) => *pos,
+        _ => {
+            warn!("[get_type_of_for_expr] invalid match type: {:?}", m.mtype);
+            return None;
+        }
+    };
+    // HACK: use outer scope when getting in ~ expr's type
+    let scope = Scope::new(m.filepath.clone(), for_start);
     let ast::ForStmtVisitor {
         for_pat, in_expr, ..
-    } = ast::parse_for_stmt(m.contextstr.clone(), Scope::from_match(m), session);
+    } = ast::parse_for_stmt(m.contextstr.clone(), scope, session);
     debug!(
         "[get_type_of_for_expr] match: {:?}, for: {:?}, in: {:?},",
         m, for_pat, in_expr
@@ -372,7 +380,34 @@ fn get_type_of_for_arg(m: &Match, session: &Session) -> Option<Ty> {
     }
     resolve_lvalue_ty(
         for_pat?,
-        Box::new(|| in_expr.and_then(|ty| get_item(ty, session))),
+        in_expr.and_then(|ty| get_item(ty, session)),
+        &m.matchstr,
+        &m.filepath,
+        m.point,
+        session,
+    )
+}
+
+fn get_type_of_if_let(m: &Match, msrc: Src, session: &Session) -> Option<Ty> {
+    let iflet_start = match &m.mtype {
+        core::MatchType::IfLet(pos) => *pos,
+        _ => {
+            warn!("[get_type_of_if_let] invalid match type: {:?}", m.mtype);
+            return None;
+        }
+    };
+    // HACK: use outer scope when getting r-value's type
+    let scope = Scope::new(m.filepath.clone(), iflet_start);
+    let ast::IfLetVisitor {
+        let_pat, rh_expr, ..
+    } = ast::parse_if_let(m.contextstr.clone(), scope, session);
+    debug!(
+        "[get_type_of_if_let] match: {:?}\n  let: {:?}\n  rh: {:?},",
+        m, let_pat, rh_expr,
+    );
+    resolve_lvalue_ty(
+        let_pat?,
+        rh_expr,
         &m.matchstr,
         &m.filepath,
         m.point,
@@ -465,9 +500,9 @@ pub fn get_type_of_match(m: Match, msrc: Src, session: &Session) -> Option<Ty> {
 
     match m.mtype {
         core::MatchType::Let => get_type_of_let_expr(&m, msrc, session),
-        core::MatchType::IfLet => get_type_of_let_block_expr(&m, msrc, session, "if let"),
-        core::MatchType::WhileLet => get_type_of_let_block_expr(&m, msrc, session, "while let"),
-        core::MatchType::For => get_type_of_for_arg(&m, session),
+        core::MatchType::IfLet(_) => get_type_of_if_let(&m, msrc, session),
+        core::MatchType::WhileLet(_) => get_type_of_let_block_expr(&m, msrc, session, "while let"),
+        core::MatchType::For(_) => get_type_of_for_arg(&m, session),
         core::MatchType::FnArg => get_type_of_fnarg(&m, msrc, session),
         core::MatchType::MatchArm => get_type_from_match_arm(&m, msrc, session),
         core::MatchType::Struct(_)

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -3,9 +3,7 @@
 use ast;
 use ast_types::{Pat, Ty};
 use core;
-use core::{
-    BytePos, MaskedSource, Match, MatchType, Namespace, Scope, SearchType, Session, SessionExt, Src,
-};
+use core::{BytePos, Match, MatchType, Namespace, Scope, SearchType, Session, SessionExt, Src};
 use matchers;
 use nameres;
 use scopes;
@@ -258,8 +256,7 @@ fn resolve_lvalue_ty<'a>(
         Pat::Tuple(pats) => {
             if let Ty::Tuple(ty) = r_value? {
                 for (p, t) in pats.into_iter().zip(ty) {
-                    let ret =
-                        try_continue!(resolve_lvalue_ty(p, Some(t), query, fpath, pos, session,));
+                    let ret = try_continue!(resolve_lvalue_ty(p, t, query, fpath, pos, session,));
                     return Some(ret);
                 }
             }
@@ -277,7 +274,7 @@ fn resolve_lvalue_ty<'a>(
             }
         }
         Pat::TupleStruct(path, pats) => {
-            let mut ma = ast::find_type_match(&path, fpath, pos, session)?;
+            let ma = ast::find_type_match(&path, fpath, pos, session)?;
             match &ma.mtype {
                 MatchType::Struct(_generics) => {
                     for (pat, (_, _, t)) in

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4501,7 +4501,7 @@ mod completes_methods_for_if_let {
     fn enum_variant_with_tuple() {
         let src = "
     fn main() {
-        let s = Some((String::new(), 0u32);
+        let s = Some((String::new(), 0u32));
         if let Some((s, _)) = s{
            s.capa~
         }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4467,9 +4467,11 @@ fn completes_trait_methods_in_path() {
     assert_eq!(got.matchstr, "default");
 }
 
-#[test]
-fn completes_methods_for_destructed_if_let() {
-    let src = "
+mod completes_methods_for_if_let {
+    use super::*;
+    #[test]
+    fn enum_with_type_annotation() {
+        let src = "
     fn main() {
         let s: Option<String> = None;
         if let Some(s) = s{
@@ -4477,8 +4479,37 @@ fn completes_methods_for_destructed_if_let() {
         }
     }
 ";
-    let got = get_only_completion(src, None);
-    assert_eq!(got.matchstr, "capacity");
+        let got = get_only_completion(src, None);
+        assert_eq!(got.matchstr, "capacity");
+    }
+
+    #[test]
+    fn enum_variant_with_path() {
+        let src = "
+    fn main() {
+        let s = Some(String::new());
+        if let Some(s) = s{
+           s.capa~
+        }
+    }
+";
+        let got = get_only_completion(src, None);
+        assert_eq!(got.matchstr, "capacity");
+    }
+
+    #[test]
+    fn enum_variant_with_tuple() {
+        let src = "
+    fn main() {
+        let s = Some((String::new(), 0u32);
+        if let Some((s, _)) = s{
+           s.capa~
+        }
+    }
+";
+        let got = get_only_completion(src, None);
+        assert_eq!(got.matchstr, "capacity");
+    }
 }
 
 // blocked by #946

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4467,6 +4467,20 @@ fn completes_trait_methods_in_path() {
     assert_eq!(got.matchstr, "default");
 }
 
+#[test]
+fn completes_methods_for_destructed_if_let() {
+    let src = "
+    fn main() {
+        let s: Option<String> = None;
+        if let Some(s) = s{
+           s.capa~
+        }
+    }
+";
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "capacity");
+}
+
 // blocked by #946
 #[test]
 #[ignore]


### PR DESCRIPTION
Enables completion for 
```rust
let s: Option<String> = None;
if let Some(s) = s{
    s.capa~
}
```

Though racer has this feature now(https://github.com/racer-rust/racer/blob/f0e100598b66fd1463bd6c67acf4d90d2806e1b5/src/racer/typeinf.rs#L244), it rarely works.

- [x] less type annotation(e.g. for `let s = Some(String::new());`)