### PR TITLE
Refactor StmtIndeicesIter

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -515,7 +515,6 @@ fn search_scope_headers(
             search_type,
             true,
         );
-
     // 'if let' can be an expression, so might not be at the start of the stmt
     } else if let Some(n) = preblock.find("if let") {
         let ifletstart = stmtstart + n.into();

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -115,16 +115,17 @@ pub fn scope_start(src: Src, point: BytePos) -> BytePos {
 }
 
 pub fn find_stmt_start(msrc: Src, point: BytePos) -> Option<BytePos> {
-    let scopestart = scope_start(msrc, point);
+    let scope_start = scope_start(msrc, point);
     // Iterate the scope to find the start of the statement that surrounds the point.
     debug!(
         "[find_stmt_start] now we are in scope {:?} ~ {:?}",
-        scopestart, point,
+        scope_start, point,
     );
-    msrc.shift_start(scopestart)
+    msrc.shift_start(scope_start)
         .iter_stmts()
-        .find(|&range| scopestart + range.start < point && point < scopestart + range.end)
-        .map(|range| scopestart + range.start)
+        .map(|range| range.shift(scope_start))
+        .find(|range| range.contains(point))
+        .map(|range| range.start)
 }
 
 /// Finds a statement start or panics.

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -29,7 +29,7 @@ pub(crate) fn is_ident_char(c: char) -> bool {
     c.is_alphanumeric() || (c == '_') || (c == '!')
 }
 
-#[inline]
+#[inline(always)]
 pub(crate) fn is_whitespace_byte(b: u8) -> bool {
     b == b' ' || b == b'\r' || b == b'\n' || b == b'\t'
 }


### PR DESCRIPTION
Now all source codes are masked when loading, so there's no need to use CodeChunkIter here.