### PR TITLE
enhance primitive support

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -440,7 +440,7 @@ fn resolve_ast_path(
         filepath,
         pos,
         core::SearchType::ExactMatch,
-        core::Namespace::Both,
+        core::Namespace::Path,
         session,
     ).nth(0)
 }
@@ -558,7 +558,7 @@ impl<'c: 's, 's> ExprTypeVisitor<'c, 's> {
 
 impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
     fn visit_expr(&mut self, expr: &ast::Expr) {
-        println!(
+        debug!(
             "ExprTypeVisitor::visit_expr {:?}(kind: {:?})",
             expr, expr.node
         );
@@ -773,7 +773,6 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                 self.visit_expr(body);
                 // TODO(kngwyu) now we don't have support for literal so don't parse index
                 // but in the future, we should handle index's type
-                println!("{:?}", self.result);
                 self.result = self
                     .result
                     .take()

--- a/src/racer/ast_types.rs
+++ b/src/racer/ast_types.rs
@@ -494,13 +494,14 @@ impl TraitBounds {
         self.0
             .iter()
             .filter_map(|ps| {
-                nameres::resolve_path_with_str(
+                nameres::resolve_path(
                     &ps.path,
                     &ps.filepath,
                     ps.point,
                     core::SearchType::ExactMatch,
-                    core::Namespace::Type,
+                    core::Namespace::Trait,
                     session,
+                    &ImportInfo::default(),
                 ).nth(0)
             }).collect()
     }
@@ -771,7 +772,7 @@ impl ImplHeader {
             self.file_path(),
             self.impl_start,
             core::SearchType::ExactMatch,
-            core::Namespace::Type,
+            core::Namespace::Trait,
             session,
             import_info,
         ).nth(0)

--- a/src/racer/ast_types.rs
+++ b/src/racer/ast_types.rs
@@ -762,15 +762,6 @@ impl ImplHeader {
     ) -> Option<Self> {
         let generics = GenericsArgs::from_generics(generics, path, offset.0 as i32);
         let scope = Scope::new(path.to_owned(), impl_start);
-        fn get_self_path(ty: &TyKind, scope: &Scope) -> Option<Path> {
-            match ty {
-                TyKind::Rptr(_, ref ty) => get_self_path(&ty.ty.node, scope),
-                TyKind::Path(_, ref path) => Some(Path::from_ast(path, &scope)),
-                // HACK: treat slice as path
-                TyKind::Slice(_) => Some(Path::single("[T]".to_owned().into())),
-                _ => None,
-            }
-        }
         let self_path = get_self_path(&self_type.node, &scope)?;
         let trait_path = otrait
             .as_ref()
@@ -824,5 +815,15 @@ impl ImplHeader {
     }
     pub(crate) fn scope_start(&self) -> BytePos {
         self.block_start.increment()
+    }
+}
+
+pub(crate) fn get_self_path(ty: &TyKind, scope: &Scope) -> Option<Path> {
+    match ty {
+        TyKind::Rptr(_, ref ty) => get_self_path(&ty.ty.node, scope),
+        TyKind::Path(_, ref path) => Some(Path::from_ast(path, &scope)),
+        // HACK: treat slice as path
+        TyKind::Slice(_) => Some(Path::single("[T]".to_owned().into())),
+        _ => None,
     }
 }

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -19,6 +19,7 @@ use syntax::source_map;
 
 use ast;
 use nameres;
+use primitive::PrimKind;
 use scopes;
 use util;
 
@@ -47,7 +48,7 @@ pub enum MatchType {
     Const,
     Static,
     Macro,
-    Builtin,
+    Builtin(PrimKind),
     /// fn f<T: Clone> or fn f(a: impl Clone) with its trait bounds
     TypeParameter(Box<TraitBounds>),
 }
@@ -76,6 +77,12 @@ impl MatchType {
 impl fmt::Display for MatchType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            MatchType::Struct(_) => write!(f, "Struct"),
+            MatchType::Method(_) => write!(f, "Method"),
+            MatchType::IfLet(_) => write!(f, "IfLet"),
+            MatchType::WhileLet(_) => write!(f, "WhileLet"),
+            MatchType::For(_) => write!(f, "For"),
+            MatchType::Enum(_) => write!(f, "Enum"),
             MatchType::EnumVariant(_) => write!(f, "EnumVariant"),
             MatchType::TypeParameter(_) => write!(f, "TypeParameter"),
             _ => fmt::Debug::fmt(self, f),
@@ -1042,7 +1049,7 @@ fn complete_from_file_(filepath: &path::Path, cursor: Location, session: &Sessio
     let expr = &src_text[start.0..pos.0];
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
-    debug!(
+    println!(
         "{:?}: contextstr is |{}|, searchstr is |{}|",
         completetype, contextstr, searchstr
     );
@@ -1194,7 +1201,6 @@ pub fn find_definition_(
     let range = scopes::expand_search_expr(src_txt, pos);
     let expr = &src[range.to_range()];
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
-
     debug!(
         "find_definition_ for |{:?}| |{:?}| {:?}",
         contextstr, searchstr, completetype

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1049,7 +1049,7 @@ fn complete_from_file_(filepath: &path::Path, cursor: Location, session: &Sessio
     let expr = &src_text[start.0..pos.0];
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
-    println!(
+    debug!(
         "{:?}: contextstr is |{}|, searchstr is |{}|",
         completetype, contextstr, searchstr
     );

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -27,6 +27,7 @@ mod matchers;
 #[cfg(feature = "metadata")]
 mod metadata;
 mod nameres;
+mod primitive;
 mod project_model;
 mod scopes;
 mod snippets;

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -2178,6 +2178,11 @@ pub(crate) fn get_field_matches_from_ty(
             // TODO(kngwyu): support impl &Type {..}
             get_field_matches_from_ty(*ty, searchstr, stype, session)
         }
+        Ty::Array(_, _) | Ty::Slice(_) => {
+            let mut m = primitive::PrimKind::Slice.to_module_match().unwrap();
+            m.matchstr = "[T]".to_owned();
+            search_for_field_or_method(m, searchstr, stype, session)
+        }
         _ => vec![],
     }
 }

--- a/src/racer/primitive.rs
+++ b/src/racer/primitive.rs
@@ -1,0 +1,128 @@
+use ast_types::PathSegment;
+use core::{BytePos, Match, MatchType, Namespace, SearchType, Session};
+use matchers::ImportInfo;
+use nameres::{self, RUST_SRC_PATH};
+
+const PRIM_DOC: &str = "libstd/primitive_docs.rs";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PrimKind {
+    Bool,
+    Never,
+    Char,
+    Unit,
+    Pointer,
+    Array,
+    Slice,
+    Str,
+    Tuple,
+    F32,
+    F64,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    Isize,
+    Usize,
+    Ref,
+    Fn,
+}
+
+// TODO: use trie
+const PRIM_KINDS: [PrimKind; 25] = [
+    PrimKind::Bool,
+    PrimKind::Never,
+    PrimKind::Char,
+    PrimKind::Unit,
+    PrimKind::Pointer,
+    PrimKind::Array,
+    PrimKind::Slice,
+    PrimKind::Str,
+    PrimKind::Tuple,
+    PrimKind::F32,
+    PrimKind::F64,
+    PrimKind::I8,
+    PrimKind::I16,
+    PrimKind::I32,
+    PrimKind::I64,
+    PrimKind::I128,
+    PrimKind::U8,
+    PrimKind::U16,
+    PrimKind::U32,
+    PrimKind::U64,
+    PrimKind::U128,
+    PrimKind::Isize,
+    PrimKind::Usize,
+    PrimKind::Ref,
+    PrimKind::Fn,
+];
+
+impl PrimKind {
+    fn match_name(self) -> &'static str {
+        match self {
+            PrimKind::Bool => "bool",
+            PrimKind::Never => "never",
+            PrimKind::Char => "char",
+            PrimKind::Unit => "unit",
+            PrimKind::Pointer => "pointer",
+            PrimKind::Array => "array",
+            PrimKind::Slice => "slice",
+            PrimKind::Str => "str",
+            PrimKind::Tuple => "tuple",
+            PrimKind::F32 => "f32",
+            PrimKind::F64 => "f64",
+            PrimKind::I8 => "i8",
+            PrimKind::I16 => "i16",
+            PrimKind::I32 => "i32",
+            PrimKind::I64 => "i64",
+            PrimKind::I128 => "i128",
+            PrimKind::U8 => "u8",
+            PrimKind::U16 => "u16",
+            PrimKind::U32 => "u32",
+            PrimKind::U64 => "u64",
+            PrimKind::U128 => "u128",
+            PrimKind::Isize => "isize",
+            PrimKind::Usize => "usize",
+            PrimKind::Ref => "ref",
+            PrimKind::Fn => "fn",
+        }
+    }
+    pub fn to_doc_match(self, session: &Session) -> Option<Match> {
+        let seg: PathSegment = format!("prim_{}", self.match_name()).into();
+        let src_path = RUST_SRC_PATH.as_ref()?;
+        let prim_path = src_path.join(PRIM_DOC);
+        let mut m = nameres::resolve_name(
+            &seg,
+            &prim_path,
+            BytePos::ZERO,
+            SearchType::ExactMatch,
+            Namespace::Mod,
+            session,
+            &ImportInfo::default(),
+        ).next()?;
+        m.mtype = MatchType::Builtin;
+        Some(m)
+    }
+}
+
+pub fn get_primitives(searchstr: &str, stype: SearchType, session: &Session, out: &mut Vec<Match>) {
+    for prim in PRIM_KINDS.iter() {
+        let prim_str = prim.match_name();
+        if (stype == SearchType::StartsWith && prim_str.starts_with(searchstr))
+            || (stype == SearchType::ExactMatch && prim_str == searchstr)
+        {
+            if let Some(m) = prim.to_doc_match(session) {
+                out.push(m);
+                if stype == SearchType::ExactMatch {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/racer/primitive.rs
+++ b/src/racer/primitive.rs
@@ -2,6 +2,7 @@ use ast_types::PathSegment;
 use core::{BytePos, Match, MatchType, Namespace, SearchType, Session};
 use matchers::ImportInfo;
 use nameres::{self, RUST_SRC_PATH};
+use std::path::PathBuf;
 
 const PRIM_DOC: &str = "libstd/primitive_docs.rs";
 
@@ -34,17 +35,10 @@ pub enum PrimKind {
     Fn,
 }
 
-// TODO: use trie
-const PRIM_KINDS: [PrimKind; 25] = [
+const PRIM_MATCHES: [PrimKind; 17] = [
     PrimKind::Bool,
-    PrimKind::Never,
     PrimKind::Char,
-    PrimKind::Unit,
-    PrimKind::Pointer,
-    PrimKind::Array,
-    PrimKind::Slice,
     PrimKind::Str,
-    PrimKind::Tuple,
     PrimKind::F32,
     PrimKind::F64,
     PrimKind::I8,
@@ -59,11 +53,60 @@ const PRIM_KINDS: [PrimKind; 25] = [
     PrimKind::U128,
     PrimKind::Isize,
     PrimKind::Usize,
-    PrimKind::Ref,
-    PrimKind::Fn,
 ];
 
 impl PrimKind {
+    fn is_int(self) -> bool {
+        match self {
+            PrimKind::I8
+            | PrimKind::I16
+            | PrimKind::I32
+            | PrimKind::I64
+            | PrimKind::I128
+            | PrimKind::Isize => true,
+            _ => false,
+        }
+    }
+    fn is_uint(self) -> bool {
+        match self {
+            PrimKind::U8
+            | PrimKind::U16
+            | PrimKind::U32
+            | PrimKind::U64
+            | PrimKind::U128
+            | PrimKind::Usize => true,
+            _ => false,
+        }
+    }
+    fn impl_files(self) -> Option<&'static [&'static str]> {
+        match self {
+            PrimKind::Bool => None,
+            PrimKind::Never => None,
+            PrimKind::Char => Some(&["libcore/char/methods.rs"]),
+            PrimKind::Unit => None,
+            PrimKind::Pointer => Some(&["libcore/ptr.rs"]),
+            PrimKind::Array => None,
+            PrimKind::Slice => Some(&["libcore/slice/mod.rs", "liballoc/slice.rs"]),
+            PrimKind::Str => Some(&["libcore/str/mod.rs", "liballoc/str.rs"]),
+            PrimKind::Tuple => None,
+            PrimKind::F32 => Some(&["libstd/f32.rs", "libcore/num/f32.rs"]),
+            PrimKind::F64 => Some(&["libstd/f64.rs", "libcore/num/f64.rs"]),
+            PrimKind::I8 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::I16 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::I32 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::I64 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::I128 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::U8 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::U16 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::U32 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::U64 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::U128 => Some(&["libcore/num/mod.rs"]),
+            PrimKind::Isize => Some(&["libcore/num/mod.rs"]),
+            PrimKind::Usize => Some(&["libcore/num/mod.rs"]),
+            PrimKind::Ref => None,
+            PrimKind::Fn => None,
+        }
+    }
     fn match_name(self) -> &'static str {
         match self {
             PrimKind::Bool => "bool",
@@ -93,6 +136,29 @@ impl PrimKind {
             PrimKind::Fn => "fn",
         }
     }
+    pub(crate) fn get_impl_files(&self) -> Option<Vec<PathBuf>> {
+        let src_path = RUST_SRC_PATH.as_ref()?;
+        let impls = self.impl_files()?;
+        Some(
+            impls
+                .iter()
+                .map(|file| src_path.join(file).to_owned())
+                .collect(),
+        )
+    }
+    pub fn to_module_matches(self) -> Option<Match> {
+        let _impl_files = self.impl_files()?;
+        Some(Match {
+            matchstr: self.match_name().to_owned(),
+            filepath: PathBuf::new(),
+            point: BytePos::ZERO,
+            coords: None,
+            local: false,
+            mtype: MatchType::Builtin(self),
+            contextstr: String::new(),
+            docs: String::new(),
+        })
+    }
     pub fn to_doc_match(self, session: &Session) -> Option<Match> {
         let seg: PathSegment = format!("prim_{}", self.match_name()).into();
         let src_path = RUST_SRC_PATH.as_ref()?;
@@ -106,19 +172,41 @@ impl PrimKind {
             session,
             &ImportInfo::default(),
         ).next()?;
-        m.mtype = MatchType::Builtin;
+        m.mtype = MatchType::Builtin(self);
+        m.matchstr = self.match_name().to_owned();
         Some(m)
     }
 }
 
-pub fn get_primitives(searchstr: &str, stype: SearchType, session: &Session, out: &mut Vec<Match>) {
-    for prim in PRIM_KINDS.iter() {
+pub fn get_primitive_docs(
+    searchstr: &str,
+    stype: SearchType,
+    session: &Session,
+    out: &mut Vec<Match>,
+) {
+    for prim in PRIM_MATCHES.iter() {
         let prim_str = prim.match_name();
         if (stype == SearchType::StartsWith && prim_str.starts_with(searchstr))
             || (stype == SearchType::ExactMatch && prim_str == searchstr)
         {
             if let Some(m) = prim.to_doc_match(session) {
                 out.push(m);
+                if stype == SearchType::ExactMatch {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+pub fn get_primitive_mods(searchstr: &str, stype: SearchType, out: &mut Vec<Match>) {
+    for prim in PRIM_MATCHES.iter() {
+        let prim_str = prim.match_name();
+        if (stype == SearchType::StartsWith && prim_str.starts_with(searchstr))
+            || (stype == SearchType::ExactMatch && prim_str == searchstr)
+        {
+            if let Some(matches) = prim.to_module_matches() {
+                out.push(matches);
                 if stype == SearchType::ExactMatch {
                     return;
                 }

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -304,6 +304,8 @@ pub fn get_start_of_search_expr(src: &str, point: BytePos) -> BytePos {
         Bracket(usize),
         /// In a string
         StringLiteral,
+        /// In char
+        CharLiteral,
         StartsWithDot,
         MustEndsWithDot(usize),
         StartsWithCol(usize),
@@ -331,6 +333,10 @@ pub fn get_start_of_search_expr(src: &str, point: BytePos) -> BytePos {
             (b'"', State::None) | (b'"', State::StartsWithDot) => State::StringLiteral,
             (b'"', State::StringLiteral) => State::None,
             (b'?', State::StartsWithDot) => State::None,
+            (b'\'', State::None) | (b'\'', State::StartsWithDot) => State::CharLiteral,
+            (b'\'', State::StringLiteral) => State::StringLiteral,
+            (b'\'', State::CharLiteral) => State::None,
+            (_, State::CharLiteral) => State::CharLiteral,
             (_, State::StringLiteral) => State::StringLiteral,
             (_, State::StartsWithCol(index)) => State::Result(index),
             (_, State::None) if char_at(src, i).is_whitespace() => State::MustEndsWithDot(i + 1),

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -265,7 +265,7 @@ fn resolve_lvalue_ty<'a>(
         }
         Pat::Ref(pat, _) => {
             if let Some(ty) = r_value {
-                if let Ty::RefPtr(ty) = ty {
+                if let Ty::RefPtr(ty, _) = ty {
                     resolve_lvalue_ty(*pat, Some(*ty), query, fpath, pos, session)
                 } else {
                     resolve_lvalue_ty(*pat, Some(ty), query, fpath, pos, session)
@@ -347,7 +347,7 @@ fn get_type_of_for_arg(m: &Match, session: &Session) -> Option<Ty> {
             Ty::PathSearch(paths) => {
                 nameres::get_iter_item(&paths.resolve_as_match(session)?, session)
             }
-            Ty::RefPtr(ty) => get_item(*ty, session),
+            Ty::RefPtr(ty, _) => get_item(*ty, session),
             _ => None,
         }
     }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -120,13 +120,14 @@ pub fn get_type_of_self(
             return Some(Ty::Match(m));
         }
         debug!("get_type_of_self_arg implres |{:?}|", implres);
-        nameres::resolve_path_with_str(
+        nameres::resolve_path(
             implres.self_path(),
             filepath,
             start,
             SearchType::ExactMatch,
             Namespace::Type,
             session,
+            &matchers::ImportInfo::default(),
         ).nth(0)
         .map(|mut m| {
             match &mut m.mtype {

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -77,3 +77,15 @@ fn completes_methods_for_char() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "is_uppercase");
 }
+
+#[test]
+fn completes_methods_for_array() {
+    let src = r#"
+    fn main() {
+        [1, 2, 3].split_mu~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "split_mut");
+}

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -49,3 +49,19 @@ fn completes_libcore_method_for_str() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "len");
 }
+
+// Experimental featrue
+#[test]
+fn completes_tuple_field() {
+    let src = "
+    fn foo() -> (usize, usize) { (1, 2) }
+    fn main() {
+        foo().~
+    }
+    ";
+    let got = get_all_completions(src, None);
+    assert!(
+        got.into_iter()
+            .all(|ma| ma.matchstr == "0" || ma.matchstr == "1")
+    )
+}

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -11,3 +11,41 @@ fn finds_def_of_i64() {
     let got = get_definition(src, None);
     assert_eq!(got.matchstr, "i64", "{:?}", got);
 }
+
+#[test]
+fn get_def_of_str_method() {
+    let src = r#"
+        fn check() {
+            "hello".to_lowerca~se();
+        }
+    "#;
+
+    let got = get_definition(src, None);
+    assert_eq!("to_lowercase", got.matchstr);
+}
+
+#[test]
+fn completes_liballoc_method_for_str() {
+    let src = r#"
+    fn in_let() {
+        let foo = "hello";
+        foo.to_lowerc~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "to_lowercase");
+}
+
+#[test]
+fn completes_libcore_method_for_str() {
+    let src = r#"
+    fn in_let() {
+        let foo = "hello";
+        foo.le~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "len");
+}

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -65,3 +65,15 @@ fn completes_tuple_field() {
             .all(|ma| ma.matchstr == "0" || ma.matchstr == "1")
     )
 }
+
+#[test]
+fn completes_methods_for_char() {
+    let src = r#"
+    fn main() {
+        'c'.is_upperc~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "is_uppercase");
+}

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -1,0 +1,13 @@
+extern crate racer_testutils;
+use racer_testutils::*;
+
+#[test]
+fn finds_def_of_i64() {
+    let src = "
+    fn main() {
+        let a: i64~ = 0;
+    }
+    ";
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "i64", "{:?}", got);
+}

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -79,7 +79,7 @@ fn completes_methods_for_char() {
 }
 
 #[test]
-fn completes_methods_for_array() {
+fn completes_slice_methods_for_array() {
     let src = r#"
     fn main() {
         [1, 2, 3].split_mu~
@@ -88,4 +88,33 @@ fn completes_methods_for_array() {
 
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "split_mut");
+}
+
+#[test]
+fn completes_methods_for_slice() {
+    let src = r#"
+    fn slice() -> &'static [usize] {
+        &[1, 2, 3]
+    }
+    fn main() {
+        let s = slice();
+        s.split_first_m~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "split_first_mut");
+}
+
+#[test]
+fn completes_slice_methods_for_vec() {
+    let src = r#"
+    fn main() {
+        let v = vec![];
+        v.split_first_m~
+    }
+    "#;
+
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "split_first_mut");
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4031,21 +4031,3 @@ fn completes_trait_methods_in_path() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "default");
 }
-
-// Experimental featrue
-// It's already implemented but has a filepath problem
-#[test]
-#[ignore]
-fn completes_tuple_field() {
-    let src = "
-    fn foo() -> (usize, usize) { (1, 2) }
-    fn main() {
-        foo().~
-    }
-    ";
-    let got = get_all_completions(src, None);
-    assert!(
-        got.into_iter()
-            .all(|ma| ma.matchstr == "0" || ma.matchstr == "1")
-    )
-}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2966,31 +2966,6 @@ fn closure_test_multiple_curly_brackets_in_args() {
 }
 
 #[test]
-fn literal_string_method() {
-    let src = r#"
-        fn check() {
-            "hello".to_lowerca~se();
-        }
-    "#;
-
-    let got = get_definition(src, None);
-    assert_eq!("to_lowercase", got.matchstr);
-}
-
-#[test]
-fn literal_string_completes() {
-    let src = r#"
-    fn in_let() {
-        let foo = "hello";
-        foo.to_lowerc~
-    }
-    "#;
-
-    let got = get_only_completion(src, None);
-    assert_eq!("to_lowercase", got.matchstr);
-}
-
-#[test]
 fn crate_restricted_fn_completes() {
     let src = r#"
     pub(crate) fn do_stuff() {


### PR DESCRIPTION
- [x] jump to primitive doc for types which has the same notation of its type name(i64, usize, ..)
- [x] jump to primitive doc for types which doesn't have the same notation of its type name(tuple, slice, ..)
  - [x] for tuple field (`t.0`)
- [x] Enable both 'libcore' and 'liballoc' method completion for 'str' 
- [x] Enable method completion for some literals(char, u8, and etc)
- [x] Enable method completion for slice