### PR TITLE
Don't decrement BytePos if BytePos less than 1

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -154,6 +154,9 @@ impl BytePos {
     pub fn decrement(&self) -> Self {
         BytePos(self.0 - 1)
     }
+    pub fn try_decrement(&self) -> Option<Self> {
+        self.0.checked_sub(1).map(BytePos)
+    }
     /// returns self + 1
     pub fn increment(&self) -> Self {
         BytePos(self.0 + 1)

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1827,7 +1827,12 @@ pub fn resolve_method(
         searchstr, point, scopestart,
     );
 
-    if let Some(stmtstart) = scopes::find_stmt_start(msrc, scopestart.decrement()) {
+    let parent_scope = match scopestart.try_decrement() {
+        Some(x) => x,
+        None => return vec![],
+    };
+
+    if let Some(stmtstart) = scopes::find_stmt_start(msrc, parent_scope) {
         let preblock = &msrc[stmtstart.0..scopestart.0];
         debug!("search_scope_headers preblock is |{}|", preblock);
 


### PR DESCRIPTION
Fix #956 

a.rs
```
fn m
```

```
$ ~/g/g/h/racer> env RUST_LOG=debug ./target/debug/racer complete 1 4 a.rs
DEBUG 2018-09-18T00:18:35.182557604Z: racer::util: Getting rust source path. Trying env var RUST_SRC_PATH.
PREFIX 3,4,a
DEBUG 2018-09-18T00:18:35.193004875Z: racer::core: Path: contextstr is ||, searchstr is |a|
DEBUG 2018-09-18T00:18:35.193772633Z: racer::scopes: [find_stmt_start] now we are in scope BytePos(0) ~ BytePos(4)
DEBUG 2018-09-18T00:18:35.194625963Z: racer::core: Complete path with line: "fn a"
DEBUG 2018-09-18T00:18:35.195390423Z: racer::nameres: resolve_method for |a| pt: BytePos(4); scopestart: BytePos(0)
thread 'searcher' panicked at 'attempt to subtract with overflow', src/racer/core.rs:155:17
```