### PR TITLE
Fix warning on build

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -583,14 +583,6 @@ fn myfn(b:usize) {
 }
 
 impl<'c> Src<'c> {
-    pub fn start(&self) -> BytePos {
-        self.range.start
-    }
-
-    pub fn end(&self) -> BytePos {
-        self.range.end
-    }
-
     pub fn iter_stmts(&self) -> Fuse<StmtIndicesIter> {
         StmtIndicesIter::from_parts(self)
     }

--- a/src/racer/primitive.rs
+++ b/src/racer/primitive.rs
@@ -78,6 +78,8 @@ impl PrimKind {
             LitIntType::Unsuffixed => PrimKind::U32,
         }
     }
+    // Do not remove this method.
+    // See #963
     fn is_int(self) -> bool {
         match self {
             PrimKind::I8
@@ -89,6 +91,8 @@ impl PrimKind {
             _ => false,
         }
     }
+    // Do not remove this method.
+    // See #963
     fn is_uint(self) -> bool {
         match self {
             PrimKind::U8


### PR DESCRIPTION
There 4 dead codes.
But I thought that these are intentionally left only because they are not used now, so I exclude them from warning.
Please let me know if this is just a missing.