### PR TITLE
Add closure completions

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -636,6 +636,19 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                                 }
                                 Some(Ty::Match(m))
                             }
+                            MatchType::TypeParameter(ref traitbounds) if traitbounds.has_closure() => {
+                                let mut output = None;
+                                if let Some(path_search) = traitbounds.get_closure()
+                                {
+                                    for seg in path_search.path.segments.iter() {
+                                        if seg.output.is_some() {
+                                            output = seg.output.clone();
+                                            break;
+                                        }
+                                    }
+                                }
+                                output
+                            }
                             _ => {
                                 debug!(
                                     "ExprTypeVisitor: Cannot handle ExprCall of {:?} type",

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -631,7 +631,7 @@ pub fn match_use(
                 let mut search_path = path_alias.path;
                 search_path
                     .segments
-                    .push(PathSegment::new(context.search_str.to_owned(), vec![]));
+                    .push(PathSegment::new(context.search_str.to_owned(), vec![], None));
                 let path_iter = resolve_path(
                     &search_path,
                     context.filepath,

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1771,7 +1771,7 @@ pub fn resolve_path(
                 if searchstr.starts_with('{') {
                     searchstr = &searchstr[1..];
                 }
-                let pathseg = PathSegment::new(searchstr.to_owned(), vec![]);
+                let pathseg = PathSegment::new(searchstr.to_owned(), vec![], None);
                 debug!(
                     "searching a module '{}' for {} (whole path: {:?})",
                     m.matchstr, pathseg.name, path
@@ -1919,7 +1919,7 @@ pub fn do_external_search(
     if path.len() == 1 {
         let searchstr = path[0];
         // hack for now
-        let pathseg = PathSegment::new(path[0].to_owned(), vec![]);
+        let pathseg = PathSegment::new(path[0].to_owned(), vec![], None);
         out.extend(search_next_scope(
             pos,
             &pathseg,
@@ -1966,7 +1966,7 @@ pub fn do_external_search(
                         Some('{') => &path[path.len() - 1][1..],
                         _ => path[path.len() - 1],
                     };
-                    let pathseg = PathSegment::new(searchstr.to_owned(), vec![]);
+                    let pathseg = PathSegment::new(searchstr.to_owned(), vec![], None);
                     for m in search_next_scope(
                         m.point,
                         &pathseg,
@@ -1991,7 +1991,7 @@ pub fn do_external_search(
                             Some('{') => &path[path.len() - 1][1..],
                             _ => path[path.len() - 1],
                         };
-                        let pathseg = PathSegment::new(searchstr.to_owned(), vec![]);
+                        let pathseg = PathSegment::new(searchstr.to_owned(), vec![], None);
                         debug!("about to search impl scope...");
                         for m in search_next_scope(
                             impl_header.impl_start(),

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3977,3 +3977,42 @@ fn completes_trait_methods_in_path() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "default");
 }
+
+#[test]
+fn completes_closure_return_type() {
+    let src = r"
+    fn second<F: Fn() -> Option<i32>>(f: F) {
+        f().un~
+    }
+";
+    let got = get_one_completion(src, None);
+    assert_eq!("unwrap", got.matchstr);
+}
+
+#[test]
+fn completes_generic_closure_return_type() {
+    let src = r"
+    fn second<T: Clone, F: Fn() -> T>(f: F) {
+        f().cl~
+    }
+";
+    let got = get_one_completion(src, None);
+    assert_eq!("clone", got.matchstr);
+}
+
+#[test]
+fn completes_impl_generic_arg_in_closure() {
+    let src = r"
+    struct Something<T> {
+        t: T
+    }
+
+    impl<M: Clone> Something<M> {
+        fn second<T, F: Fn(T) -> M>(f: F) {
+            f().cl~
+        }
+    }
+";
+    let got = get_one_completion(src, None);
+    assert_eq!("clone", got.matchstr);
+}


### PR DESCRIPTION
Adds support for closure return types; There is no functionality for closures which are not annotated ([link](https://github.com/racer-rust/racer/blob/master/src/racer/ast.rs#L1273)) so I haven't spent time on supporting cases like:
```rust
fn main() {
    let f = |x: i32| Some(x * 2);
    f().un~
}
```
Thanks!