### PR TITLE
Type inference for struct field via function bound

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -714,8 +714,10 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                         })
                         .nth(0)
                 };
-                self.result =
-                    result.and_then(|ty| ty.resolve(self.session).and_then(get_method_output_ty));
+                self.result = result.and_then(|ty| {
+                    ty.resolve_as_match(false, self.session)
+                        .and_then(get_method_output_ty)
+                });
             }
             ExprKind::Field(ref subexpression, spannedident) => {
                 let fieldname = spannedident.name.to_string();
@@ -735,8 +737,10 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                         },
                     )
                 };
-                self.result =
-                    result.and_then(|ty| ty.resolve(self.session).and_then(match_to_field_ty));
+                self.result = result.and_then(|ty| {
+                    ty.resolve_as_match(true, self.session)
+                        .and_then(match_to_field_ty)
+                });
             }
             ExprKind::Tup(ref exprs) => {
                 let mut v = Vec::new();

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -189,26 +189,37 @@ impl<'ast> visit::Visitor<'ast> for PatVisitor {
     }
 }
 
-pub struct PatAndGenVisitor<'f> {
-    ident_points: Vec<ByteRange>,
+pub struct FnArgVisitor {
+    idents: Vec<(Pat, Option<Ty>, ByteRange)>,
     generics: GenericsArgs,
-    fpath: &'f Path,
+    scope: Scope,
     offset: i32,
 }
 
-impl<'ast, 'f> visit::Visitor<'ast> for PatAndGenVisitor<'f> {
-    fn visit_pat(&mut self, p: &ast::Pat) {
-        match p.node {
-            PatKind::Ident(_, ref spannedident, _) => {
-                self.ident_points.push(spannedident.span.into());
-            }
-            _ => {
-                visit::walk_pat(self, p);
-            }
-        }
+impl<'ast> visit::Visitor<'ast> for FnArgVisitor {
+    fn visit_fn(
+        &mut self,
+        _fk: visit::FnKind,
+        fd: &ast::FnDecl,
+        _: source_map::Span,
+        _: ast::NodeId,
+    ) {
+        debug!("[FnArgVisitor::visit_fn] inputs: {:?}", fd.inputs);
+        self.idents = fd
+            .inputs
+            .iter()
+            .map(|arg| {
+                debug!("[FnArgTypeVisitor::visit_fn] type {:?} was found", arg.ty);
+                let pat = Pat::from_ast(&arg.pat.node, &self.scope);
+                let ty = Ty::from_ast(&arg.ty, &self.scope);
+                let source_map::BytePos(lo) = arg.pat.span.lo();
+                let source_map::BytePos(hi) = arg.ty.span.hi();
+                (pat, ty, ByteRange::new(lo, hi))
+            })
+            .collect();
     }
     fn visit_generics(&mut self, g: &'ast ast::Generics) {
-        let generics = GenericsArgs::from_generics(g, self.fpath, self.offset);
+        let generics = GenericsArgs::from_generics(g, &self.scope.filepath, self.offset);
         self.generics.extend(generics);
     }
 }
@@ -680,10 +691,10 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                 // arguments[0] is receiver(e.g. self)
                 let objexpr = &arguments[0];
                 self.visit_expr(objexpr);
-
-                let get_method_call_output_type = |contextm: &Match| {
+                let result = self.result.take();
+                let get_method_output_ty = |contextm: Match| {
                     let matching_methods = nameres::search_for_impl_methods(
-                        contextm,
+                        &contextm,
                         &methodname,
                         contextm.point,
                         &contextm.filepath,
@@ -694,46 +705,38 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                     matching_methods
                         .into_iter()
                         .map(|method| {
-                            typeinf::get_return_type_of_function(&method, contextm, self.session)
+                            typeinf::get_return_type_of_function(&method, &contextm, self.session)
                         })
                         .filter_map(|ty| {
                             ty.and_then(|ty| {
-                                path_to_match_including_generics(ty, contextm, self.session)
+                                path_to_match_including_generics(ty, &contextm, self.session)
                             })
                         })
                         .nth(0)
                 };
-
-                self.result = self.result.as_ref().and_then(|contextm| match contextm {
-                    Ty::Match(contextm) => get_method_call_output_type(contextm),
-                    Ty::PathSearch(paths) => {
-                        find_type_match(&paths.path, &paths.filepath, paths.point, self.session)
-                            .as_ref()
-                            .and_then(get_method_call_output_type)
-                    }
-                    _ => None,
-                });
+                self.result =
+                    result.and_then(|ty| ty.resolve(self.session).and_then(get_method_output_ty));
             }
             ExprKind::Field(ref subexpression, spannedident) => {
                 let fieldname = spannedident.name.to_string();
                 debug!("exprfield {}", fieldname);
                 self.visit_expr(subexpression);
-                self.result = self.result.take().and_then(|structm| match structm {
-                    Ty::Match(structm) => {
-                        typeinf::get_struct_field_type(&fieldname, &structm, self.session).and_then(
-                            |fieldtypepath| {
-                                find_type_match_including_generics(
-                                    fieldtypepath,
-                                    &structm.filepath,
-                                    structm.point,
-                                    &structm,
-                                    self.session,
-                                )
-                            },
-                        )
-                    }
-                    _ => None,
-                });
+                let result = self.result.take();
+                let match_to_field_ty = |structm: Match| {
+                    typeinf::get_struct_field_type(&fieldname, &structm, self.session).and_then(
+                        |fieldtypepath| {
+                            find_type_match_including_generics(
+                                fieldtypepath,
+                                &structm.filepath,
+                                structm.point,
+                                &structm,
+                                self.session,
+                            )
+                        },
+                    )
+                };
+                self.result =
+                    result.and_then(|ty| ty.resolve(self.session).and_then(match_to_field_ty));
             }
             ExprKind::Tup(ref exprs) => {
                 let mut v = Vec::new();
@@ -1157,21 +1160,28 @@ pub fn parse_type<'s>(s: String, scope: &'s Scope) -> TypeVisitor<'s> {
 
 pub fn parse_fn_args_and_generics(
     s: String,
-    fpath: &Path,
+    scope: Scope,
     offset: i32,
-) -> (Vec<ByteRange>, GenericsArgs) {
-    let mut v = PatAndGenVisitor {
-        ident_points: vec![],
+) -> (Vec<(Pat, Option<Ty>, ByteRange)>, GenericsArgs) {
+    let mut v = FnArgVisitor {
+        idents: Vec::new(),
         generics: GenericsArgs::default(),
-        fpath,
+        scope,
         offset,
     };
     with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
-    (v.ident_points, v.generics)
+    (v.idents, v.generics)
 }
 
-pub fn parse_fn_args(s: String) -> Vec<ByteRange> {
-    parse_pat_idents(s)
+pub fn parse_closure_args(s: String, scope: Scope) -> Vec<(Pat, Option<Ty>, ByteRange)> {
+    let mut v = FnArgVisitor {
+        idents: Vec::new(),
+        generics: GenericsArgs::default(),
+        scope,
+        offset: 0,
+    };
+    with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
+    v.idents
 }
 
 pub fn parse_pat_idents(s: String) -> Vec<ByteRange> {
@@ -1187,26 +1197,6 @@ pub fn parse_fn_output(s: String, scope: Scope) -> Option<Ty> {
     let mut v = FnOutputVisitor {
         result: None,
         scope,
-    };
-    with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
-    v.result
-}
-
-pub fn parse_fn_arg_type(
-    s: String,
-    argpos: BytePos,
-    scope: Scope,
-    session: &Session,
-    offset: i32,
-) -> Option<Ty> {
-    debug!("parse_fn_arg {:?} |{}|", argpos, s);
-    let mut v = FnArgTypeVisitor {
-        argpos,
-        scope,
-        session,
-        generics: GenericsArgs::default(),
-        offset,
-        result: None,
     };
     with_stmt(s, |stmt| visit::walk_stmt(&mut v, stmt));
     v.result
@@ -1289,75 +1279,6 @@ impl<'ast> visit::Visitor<'ast> for FnOutputVisitor {
             FunctionRetTy::Ty(ref ty) => Ty::from_ast(ty, &self.scope),
             FunctionRetTy::Default(_) => None,
         };
-    }
-}
-
-/// Visitor to detect type of fnarg
-pub struct FnArgTypeVisitor<'c: 's, 's> {
-    /// the code point arg appears in search string
-    argpos: BytePos,
-    scope: Scope,
-    session: &'s Session<'c>,
-    generics: GenericsArgs,
-    /// the code point search string starts
-    /// use i32 for the case `impl blah {` is inserted
-    offset: i32,
-    pub result: Option<Ty>,
-}
-
-impl<'c, 's, 'ast> visit::Visitor<'ast> for FnArgTypeVisitor<'c, 's> {
-    fn visit_generics(&mut self, g: &'ast ast::Generics) {
-        let filepath = &self.scope.filepath;
-        let generics = GenericsArgs::from_generics(g, filepath, self.offset);
-        debug!(
-            "[FnArgTypeVisitor::visit_generics] {:?}",
-            self.generics.get_idents()
-        );
-        self.generics.extend(generics);
-    }
-
-    fn visit_fn(
-        &mut self,
-        _fk: visit::FnKind,
-        fd: &ast::FnDecl,
-        _: source_map::Span,
-        _: ast::NodeId,
-    ) {
-        debug!("[FnArgTypeVisitor::visit_fn] inputs: {:?}", fd.inputs);
-        // Get generics arguments here (just for speed up)
-        self.result = fd
-            .inputs
-            .iter()
-            .find(|arg| point_is_in_span(self.argpos, &arg.pat.span))
-            .and_then(|arg| {
-                debug!("[FnArgTypeVisitor::visit_fn] type {:?} was found", arg.ty);
-                let ty = Ty::from_ast(&arg.ty, &self.scope)
-                    .and_then(|ty| {
-                        destructure_pattern_to_ty(
-                            &arg.pat,
-                            self.argpos,
-                            &ty,
-                            &self.scope,
-                            self.session,
-                        )
-                    })
-                    .map(Ty::dereference)?;
-                if let Ty::PathSearch(ref paths) = ty {
-                    let segments = &paths.path.segments;
-                    // now we want to get 'T' from fn f<T>(){}, so segments.len() == 1
-                    if segments.len() == 1 {
-                        let name = &segments[0].name;
-                        if let Some(bounds) = self.generics.find_type_param(name) {
-                            let res = bounds.to_owned().into_match();
-                            return Some(Ty::Match(res));
-                        }
-                    }
-                    find_type_match(&paths.path, &paths.filepath, paths.point, self.session)
-                        .map(Ty::Match)
-                } else {
-                    Some(ty)
-                }
-            });
     }
 }
 

--- a/src/racer/ast_types.rs
+++ b/src/racer/ast_types.rs
@@ -1,6 +1,6 @@
 //! type conversion between racer types and libsyntax types
 use super::ast::find_type_match;
-use core::{self, BytePos, Match, MatchType, Scope, Session};
+use core::{self, BytePos, Match, MatchType, Scope, SearchType, Session, SessionExt};
 use matchers::ImportInfo;
 use nameres;
 use primitive::PrimKind;
@@ -10,6 +10,8 @@ use syntax::ast::{
     self, GenericBound, GenericBounds, GenericParamKind, LitKind, PatKind, TraitRef, TyKind,
     WherePredicate,
 };
+use typeinf;
+use util;
 // we can only re-export types without thread-local interned string
 pub use syntax::ast::{BindingMode, Mutability};
 use syntax::print::pprust;
@@ -50,11 +52,12 @@ pub enum Ty {
     Slice(Box<Ty>),
     Ptr(Box<Ty>, Mutability),
     TraitObject(TraitBounds),
+    Self_(Scope),
     Unsupported,
 }
 
 impl Ty {
-    pub(crate) fn replace_by_generics(self, gen: &GenericsArgs) -> Self {
+    pub(crate) fn replace_by_resolved_generics(self, gen: &GenericsArgs) -> Self {
         let (ty, deref_cnt) = self.deref_with_count(0);
         if let Ty::PathSearch(ref paths) = ty {
             if let Some((_, param)) = gen.search_param_by_path(&paths.path) {
@@ -65,7 +68,21 @@ impl Ty {
         }
         ty.wrap_by_ref(deref_cnt)
     }
-
+    pub(crate) fn replace_by_generics(self, gen: &GenericsArgs) -> Self {
+        let (mut ty, deref_cnt) = self.deref_with_count(0);
+        if let Ty::PathSearch(ref mut paths) = ty {
+            if let Some((_, param)) = gen.search_param_by_path(&paths.path) {
+                if let Some(resolved) = param.resolved() {
+                    return resolved.to_owned().wrap_by_ref(deref_cnt);
+                } else {
+                    return Ty::Match(param.clone().into_match());
+                }
+            } else {
+                paths.path.replace_by_bounds(gen);
+            }
+        }
+        ty.wrap_by_ref(deref_cnt)
+    }
     pub(crate) fn dereference(self) -> Self {
         if let Ty::RefPtr(ty, _) = self {
             ty.dereference()
@@ -117,6 +134,7 @@ impl Ty {
                     ty.span.lo().0 as i32,
                 )))
             }
+            TyKind::ImplicitSelf => Some(Ty::Self_(scope.clone())),
             _ => {
                 trace!("unhandled Ty node: {:?}", ty.node);
                 None
@@ -138,6 +156,32 @@ impl Ty {
             },
             LitKind::FloatUnsuffixed(_) => make_match(PrimKind::F32),
             LitKind::Bool(_) => make_match(PrimKind::Bool),
+        }
+    }
+    // TODO: this function should be sepatated into 2,
+    // 1. for methods
+    // 2. for fields
+    pub(crate) fn resolve(self, session: &Session) -> Option<Match> {
+        match self.dereference() {
+            Ty::Match(m) => Some(m),
+            Ty::PathSearch(paths) => {
+                find_type_match(&paths.path, &paths.filepath, paths.point, session)
+            }
+            Ty::Self_(scope) => {
+                let msrc = session.load_source_file(&scope.filepath);
+                let ty = typeinf::get_type_of_self(
+                    scope.point,
+                    &scope.filepath,
+                    true,
+                    msrc.as_src(),
+                    session,
+                );
+                match ty {
+                    Some(Ty::Match(m)) => Some(m),
+                    _ => None,
+                }
+            }
+            _ => None,
         }
     }
 }
@@ -193,6 +237,7 @@ impl fmt::Display for Ty {
                 }
                 write!(f, ">")
             }
+            Ty::Self_(_) => write!(f, "Self"),
             Ty::Unsupported => write!(f, "_"),
         }
     }
@@ -217,7 +262,29 @@ pub enum Pat {
 }
 
 impl Pat {
-    pub fn from_ast(pat: &PatKind, scope: &Scope) -> Self {
+    pub(crate) fn search_by_name(&self, sname: &str, stype: SearchType) -> Option<String> {
+        match self {
+            Pat::Wild => None,
+            Pat::Ident(_, name) => {
+                if util::symbol_matches(stype, sname, name) {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            }
+            Pat::Struct(_, pats) => pats
+                .iter()
+                .filter_map(|pat| pat.pat.search_by_name(sname, stype))
+                .next(),
+            Pat::TupleStruct(_, pats) | Pat::Tuple(pats) => pats
+                .iter()
+                .filter_map(|pat| pat.search_by_name(sname, stype))
+                .next(),
+            Pat::Ref(pat, _) => pat.search_by_name(sname, stype),
+            _ => None,
+        }
+    }
+    pub(crate) fn from_ast(pat: &PatKind, scope: &Scope) -> Self {
         match pat {
             PatKind::Wild => Pat::Wild,
             PatKind::Ident(bi, ident, _) => Pat::Ident(*bi, ident.to_string()),
@@ -303,6 +370,25 @@ pub struct Path {
 }
 
 impl Path {
+    pub(crate) fn replace_by_bounds(&mut self, gen: &GenericsArgs) {
+        self.segments.iter_mut().for_each(|segment| {
+            segment
+                .generics
+                .iter_mut()
+                .for_each(|generic| match generic {
+                    Ty::PathSearch(ref mut ps) => {
+                        // TODO(kngwyu): 'resolved' case
+                        if let Some(ty) = gen.get_tbound_match(&ps.path.segments[0].name) {
+                            *generic = Ty::Match(ty);
+                        } else {
+                            ps.path.replace_by_bounds(gen);
+                        }
+                    }
+                    _ => {}
+                })
+        })
+    }
+
     pub fn is_single(&self) -> bool {
         self.segments.len() == 1
     }
@@ -719,9 +805,6 @@ impl TypeParameter {
 pub struct GenericsArgs(pub Vec<TypeParameter>);
 
 impl GenericsArgs {
-    pub(crate) fn find_type_param(&self, name: &str) -> Option<&TypeParameter> {
-        self.0.iter().find(|v| &v.name == name)
-    }
     pub(crate) fn extend(&mut self, other: GenericsArgs) {
         self.0.extend(other.0);
     }
@@ -788,57 +871,22 @@ impl GenericsArgs {
             tp: &mut TypeParameter,
             args: &GenericsArgs,
         ) {
-            fn get_match_from_args(name: &str, args: &GenericsArgs) -> Option<Ty> {
-                args.search_param_by_name(name).and_then(|(_, tp)| {
-                    let m = Match {
-                        matchstr: tp.name.clone(),
-                        mtype: MatchType::TypeParameter(Box::new(tp.bounds.clone())),
-                        contextstr: String::new(),
-                        filepath: tp.filepath.clone(),
-                        coords: None,
-                        local: false,
-                        point: tp.point,
-                        docs: String::new(),
-                    };
-                    Some(Ty::Match(m))
-                })
-            };
-
-            fn replace_with_bounds(ps: &mut PathSearch, args: &GenericsArgs) {
-                ps.path.segments.iter_mut().for_each(|segment| {
-                    segment
-                        .generics
-                        .iter_mut()
-                        .for_each(|generic| match generic {
-                            &mut Ty::PathSearch(ref mut ps) => {
-                                if let Some(ty) =
-                                    get_match_from_args(&ps.path.segments[0].name, args)
-                                {
-                                    *generic = ty;
-                                } else {
-                                    replace_with_bounds(ps, args);
-                                }
-                            }
-                            _ => {}
-                        })
-                })
-            }
-
             if let Some(ps) = tp.bounds.get_closure_mut() {
                 for segment in ps.path.segments.iter_mut() {
-                    segment.output = segment.output.take().and_then(|ty| match ty {
-                        Ty::PathSearch(ps) => {
-                            let mut output = get_match_from_args(&ps.path.segments[0].name, args)
-                                .or_else(|| Some(Ty::PathSearch(ps)));
-                            // if output is a PathSearch, it may have generics
-                            // eg. Option<T> or Box<Vec<T>>, so recursively replace
-                            // them with that of the enclosing function's type params
-                            if let Some(Ty::PathSearch(ref mut ps)) = output {
-                                replace_with_bounds(ps, args);
+                    segment.output = segment.output.take().map(|ty| match ty {
+                        Ty::PathSearch(mut ps) => {
+                            match args.get_tbound_match(&ps.path.segments[0].name) {
+                                Some(m) => Ty::Match(m),
+                                None => {
+                                    // if output is a PathSearch, it may have generics
+                                    // eg. Option<T> or Box<Vec<T>>, so recursively replace
+                                    // them with that of the enclosing function's type params
+                                    ps.path.replace_by_bounds(args);
+                                    Ty::PathSearch(ps)
+                                }
                             }
-                            output
                         }
-                        ty => Some(ty),
+                        ty => ty,
                     });
                 }
             }
@@ -882,6 +930,9 @@ impl GenericsArgs {
             }
         }
         None
+    }
+    pub fn get_tbound_match(&self, name: &str) -> Option<Match> {
+        Some(self.search_param_by_name(name)?.1.clone().into_match())
     }
     pub(crate) fn add_bound(&mut self, pos: usize, bound: TraitBounds) {
         if let Some(param) = self.0.get_mut(pos) {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1101,7 +1101,7 @@ fn complete_from_file_(filepath: &path::Path, cursor: Location, session: &Sessio
         }
         CompletionType::Field => {
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
-            println!("complete_from_file context is {:?}", context);
+            debug!("complete_from_file context is {:?}", context);
             if let Some(ty) = context {
                 out.extend(nameres::get_field_matches_from_ty(
                     ty,

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1,4 +1,4 @@
-use ast_types::{GenericsArgs, ImplHeader, Path, TraitBounds, Ty, TypeParameter};
+use ast_types::{GenericsArgs, ImplHeader, Pat, Path, TraitBounds, Ty, TypeParameter};
 use codecleaner;
 use codeiter::StmtIndicesIter;
 use matchers::ImportInfo;
@@ -43,7 +43,7 @@ pub enum MatchType {
     /// EnumVariant needs to have Enum type to complete methods
     EnumVariant(Option<Box<Match>>),
     Type,
-    FnArg,
+    FnArg(Box<(Pat, Option<Ty>)>),
     Trait,
     Const,
     Static,
@@ -85,6 +85,7 @@ impl fmt::Display for MatchType {
             MatchType::Enum(_) => write!(f, "Enum"),
             MatchType::EnumVariant(_) => write!(f, "EnumVariant"),
             MatchType::TypeParameter(_) => write!(f, "TypeParameter"),
+            MatchType::FnArg(_) => write!(f, "FnArg"),
             _ => fmt::Debug::fmt(self, f),
         }
     }
@@ -411,7 +412,7 @@ impl fmt::Debug for Match {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Scope {
     pub filepath: path::PathBuf,
     pub point: BytePos,
@@ -1100,7 +1101,7 @@ fn complete_from_file_(filepath: &path::Path, cursor: Location, session: &Sessio
         }
         CompletionType::Field => {
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
-            debug!("complete_from_file context is {:?}", context);
+            println!("complete_from_file context is {:?}", context);
             if let Some(ty) = context {
                 out.extend(nameres::get_field_matches_from_ty(
                     ty,
@@ -1320,7 +1321,7 @@ mod tests {
         // Cache contents for a file and assert that load_file and load_file_and_mask_comments return
         // the newly cached contents.
         macro_rules! cache_and_assert {
-            ($src:ident) => {{
+            ($src: ident) => {{
                 let session = Session::new(&cache);
                 session.cache_file_contents(path, $src);
                 assert_eq!($src, &session.load_raw_file(path)[..]);

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1495,10 +1495,10 @@ fn follows_chained_method_call() {
     let src = "
     struct Foo;
     struct Bar;
-    impl<T> Foo<T> {
+    impl Foo {
         fn mymethod(&self) -> Bar {}
     }
-    impl<T> Bar<T> {
+    impl Bar {
         fn mybarmethod(&self) -> Bar {}
     }
 

--- a/tests/trait_bounds.rs
+++ b/tests/trait_bounds.rs
@@ -179,3 +179,19 @@ fn completes_impled_bounds_for_ref_self_field() {
         ";
     assert_eq!(get_only_completion(src, None).matchstr, "method");
 }
+
+#[test]
+fn completes_fn_bounds_for_struct_member() {
+    let src = "
+        fn main() {
+            struct St<T> {
+                mem1: String,
+                mem2: T,
+            }
+            fn f<T: Clone>(st: St<T>) {
+                st.mem2.clone_fro~
+            }
+        }
+        ";
+    assert_eq!(get_only_completion(src, None).matchstr, "clone_from");
+}


### PR DESCRIPTION
Enables
```rust
impl<T: Clone> S<T> {
    fn f(self) {
        let b = a.mem.clo~
    } 
}
```
In addition, this PR removes `FnArgTypeVisitor`.
Currently we parse function twice for getting ident and getting type, which makes code too complicated.
So in this PR, I changed to parse function only once.