### PR TITLE
Fix completion for use as

### DIFF
--- a/src/racer/ast_types.rs
+++ b/src/racer/ast_types.rs
@@ -1,6 +1,6 @@
 //! type conversion between racer types and libsyntax types
 use super::ast::find_type_match;
-use core::{self, BytePos, Match, MatchType, Scope, SearchType, Session, SessionExt};
+use core::{self, BytePos, ByteRange, Match, MatchType, Scope, SearchType, Session, SessionExt};
 use matchers::ImportInfo;
 use nameres;
 use primitive;
@@ -27,11 +27,13 @@ pub struct PathAlias {
     pub kind: PathAliasKind,
     /// The path.
     pub path: Path,
+    /// range of item
+    pub range: ByteRange,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PathAliasKind {
-    Ident(String),
+    Ident(String, Option<BytePos>),
     Self_(String),
     Glob,
 }

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -42,7 +42,7 @@ pub enum MatchType {
     Enum(Box<GenericsArgs>),
     /// EnumVariant needs to have Enum type to complete methods
     EnumVariant(Option<Box<Match>>),
-    Type,
+    Type(Option<Box<Match>>),
     FnArg(Box<(Pat, Option<Ty>)>),
     Trait,
     Const,
@@ -86,6 +86,7 @@ impl fmt::Display for MatchType {
             MatchType::EnumVariant(_) => write!(f, "EnumVariant"),
             MatchType::TypeParameter(_) => write!(f, "TypeParameter"),
             MatchType::FnArg(_) => write!(f, "FnArg"),
+            MatchType::Type(_) => write!(f, "Type"),
             _ => fmt::Debug::fmt(self, f),
         }
     }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1765,7 +1765,8 @@ pub fn resolve_path(
         )
         .into_iter()
         .nth(0);
-        context.map(|m| match m.mtype {
+        println!("{:?}", context);
+        context.map(|mut m| match m.mtype {
             MatchType::Module => {
                 let mut searchstr: &str = &path.segments[len - 1].name;
                 if let Some(i) = searchstr.rfind(',') {
@@ -1805,8 +1806,11 @@ pub fn resolve_path(
                     out.extend(collect_trait_methods(&m, search_type, name, true, session));
                 }
             }
-            MatchType::Type => {
-                if let Some(match_) = ast::get_type_of_typedef(&m, session) {
+            MatchType::Type(ref mut resolved) => {
+                let resolved = resolved.take().map(|x| *x);
+                println!("{:?}", resolved);
+                if let Some(match_) = resolved.or_else(|| ast::get_type_of_typedef(&m, session)) {
+                    println!("path: {:?}", &path.segments[len - 1]);
                     out.extend(get_path_items(
                         &path.segments[len - 1],
                         namespace,

--- a/tests/alias.rs
+++ b/tests/alias.rs
@@ -1,0 +1,93 @@
+extern crate racer;
+extern crate racer_testutils;
+use racer::Coordinate;
+use racer_testutils::*;
+
+#[test]
+fn complets_static_methods_for_alias() {
+    let src = r#"
+        mod mymod {
+            pub struct St {
+                mem1: String,
+                mem2: usize,
+            }
+            impl St {
+                pub fn new() -> Self {
+                    St { mem1: "a".to_owned(), mem2: 5 }
+                }
+            }
+        }
+        fn main() {
+            use mymod::St as S;
+            let s = S::ne~
+        }
+    "#;
+    assert_eq!(get_only_completion(src, None).matchstr, "new");
+}
+
+#[test]
+fn finds_definition_of_use_as() {
+    let src = r#"
+        mod mymod {
+            pub struct St {
+                mem1: String,
+                mem2: usize,
+            }
+        }
+        fn main() {
+            use mymod::St as S;
+            let s = S~::new();
+        }
+    "#;
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "S");
+    assert_eq!(got.coords.unwrap(), Coordinate::new(9, 29));
+}
+
+// moved from system.rs
+#[test]
+fn follows_use_as() {
+    let src2 = "
+    pub fn myfn() {}
+    pub fn foo() {}
+    ";
+    let src = "
+    use src2::myfn as myfoofn;
+    mod src2;
+    fn main() {
+        my~foofn();
+    }
+    ";
+
+    let dir = TmpDir::new();
+    let _src2 = dir.write_file("src2.rs", src2);
+    let got = get_definition(src, Some(dir));
+    assert_eq!(got.matchstr, "myfoofn");
+    assert_eq!(got.contextstr, "src2::myfn as myfoofn");
+}
+
+// moved from system.rs
+/// Verifies fix for https://github.com/racer-rust/racer/issues/753
+#[test]
+fn follows_use_as_in_braces() {
+    let src = "
+        mod m {
+        pub struct Wrapper {
+            pub x: i32,
+        }
+
+        pub struct Second {
+            pub y: i32,
+        }
+    }
+
+    fn main() {
+        use m::{Wrapper as Wpr, Second};
+        let _ = W~pr { x: 1 };
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!(got.matchstr, "Wpr");
+    assert_eq!(got.contextstr, "Wrapper as Wpr");
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -590,52 +590,6 @@ fn follows_use_in_braces() {
 }
 
 #[test]
-fn follows_use_as() {
-    let src2 = "
-    pub fn myfn() {}
-    pub fn foo() {}
-    ";
-    let src = "
-    use src2::myfn as myfoofn;
-    mod src2;
-    fn main() {
-        my~foofn();
-    }
-    ";
-
-    let dir = TmpDir::new();
-    let _src2 = dir.write_file("src2.rs", src2);
-    let got = get_definition(src, Some(dir));
-    assert_eq!(got.matchstr, "myfoofn");
-    assert_eq!(got.contextstr, "pub fn myfn()");
-}
-
-/// Verifies fix for https://github.com/racer-rust/racer/issues/753
-#[test]
-fn follows_use_as_in_braces() {
-    let src = "
-        mod m {
-        pub struct Wrapper {
-            pub x: i32,
-        }
-
-        pub struct Second {
-            pub y: i32,
-        }
-    }
-
-    fn main() {
-        use m::{Wrapper as Wpr, Second};
-        let _ = W~pr { x: 1 };
-    }
-    ";
-
-    let got = get_definition(src, None);
-    assert_eq!(got.matchstr, "Wpr");
-    assert_eq!(got.contextstr, "pub struct Wrapper");
-}
-
-#[test]
 fn follows_use_glob() {
     let src3 = "
     pub fn myfn() {}


### PR DESCRIPTION
Fix #917 
And by this PR, we become to jump to `as B` when we use finds def command on `B`.
```rust
use A as B;
let b: B = ~
```