### PR TITLE
Completes associated function & type for type parameter

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -44,6 +44,7 @@ pub enum MatchType {
     /// EnumVariant needs to have Enum type to complete methods
     EnumVariant(Option<Box<Match>>),
     UseAlias(Box<Match>),
+    AssocType,
     Type,
     FnArg(Box<(Pat, Option<Ty>)>),
     Trait,

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -456,7 +456,7 @@ pub fn match_type(msrc: Src, context: &MatchCxt, session: &Session) -> Option<Ma
 
 pub fn match_trait(msrc: Src, context: &MatchCxt, session: &Session) -> Option<Match> {
     let blob = &msrc[context.range.to_range()];
-    let (start, s) = context.get_key_ident(blob, "trait", &[])?;
+    let (start, s) = context.get_key_ident(blob, "trait", &["unsafe"])?;
     debug!("found!! a trait {}", s);
     let start = context.range.start + start;
     let doc_src = session.load_raw_src_ranged(&msrc, context.filepath);
@@ -686,6 +686,23 @@ pub fn match_fn(msrc: Src, context: &MatchCxt, session: &Session) -> Option<Matc
     if typeinf::first_param_is_self(blob) {
         return None;
     }
+    match_fn_common(blob, msrc, context, session)
+}
+
+pub fn match_method(
+    msrc: Src,
+    context: &MatchCxt,
+    include_assoc_fn: bool,
+    session: &Session,
+) -> Option<Match> {
+    let blob = &msrc[context.range.to_range()];
+    if !include_assoc_fn && !typeinf::first_param_is_self(blob) {
+        return None;
+    }
+    match_fn_common(blob, msrc, context, session)
+}
+
+fn match_fn_common(blob: &str, msrc: Src, context: &MatchCxt, session: &Session) -> Option<Match> {
     let (start, s) = context.get_key_ident(blob, "fn", &["const", "unsafe"])?;
     let start = context.range.start + start;
     let doc_src = session.load_raw_src_ranged(&msrc, context.filepath);

--- a/tests/trait_bounds.rs
+++ b/tests/trait_bounds.rs
@@ -270,3 +270,78 @@ mod m {
     ";
     assert_eq!(get_only_completion(src, None).matchstr, "method");
 }
+
+#[test]
+fn completes_unsafe_trait_methods_for_fnarg() {
+    let src = "
+        fn main() {
+            unsafe trait Trait {
+                fn method(&self);
+            }
+            fn func<T: Trait>(arg: &T) {
+                unsafe { arg.meth~ }
+            }
+        }
+        ";
+    assert_eq!(get_only_completion(src, None).matchstr, "method");
+}
+
+#[test]
+fn completes_assoc_type_for_type_param_fn_bound() {
+    let src = "
+    trait Object {
+        type BaseObj: Object;
+    }
+    fn f<O: Object>(o: O) {
+        O::Base~
+    }
+    ";
+    assert_eq!(get_only_completion(src, None).matchstr, "BaseObj");
+}
+
+#[test]
+fn completes_assoc_fn_for_type_param_fn_bound() {
+    let src = "
+    trait Object {
+        fn init_typeobj() {}
+    }
+    fn f<O: Object>(o: O) {
+        O::init_~
+    }
+    ";
+    assert_eq!(get_only_completion(src, None).matchstr, "init_typeobj");
+}
+
+#[test]
+fn completes_assoc_type_for_type_param_impl_bound() {
+    let src = "
+    trait Object {
+        type BaseObj: Object;
+    }
+    struct ObjectWrapper<O> {
+        inner: O,
+    }
+    impl<O: Object> ObjectWrapper<O> {
+        const A: O::BaseO~
+    }
+    ";
+    assert_eq!(get_only_completion(src, None).matchstr, "BaseObj");
+}
+
+#[test]
+fn completes_assoc_fn_for_type_param_impl_bound() {
+    let src = "
+    trait Object {
+        fn init_typeobj() {}
+    }
+    struct ObjectWrapper<O> {
+        inner: O,
+    }
+    impl<O: Object> ObjectWrapper<O> {
+        fn method(&self) {
+            O::init~
+        }
+    }
+    ";
+    assert_eq!(get_only_completion(src, None).matchstr, "init_typeobj");
+}


### PR DESCRIPTION
Enable
```rust
fn f<C: Clone>(c: C) { C::clo~ }
```