### PR TITLE
Change struct fields' contextstr

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -842,7 +842,7 @@ fn find_type_match_including_generics(
 
 struct StructVisitor {
     pub scope: Scope,
-    pub fields: Vec<(String, BytePos, Option<Ty>)>,
+    pub fields: Vec<(String, ByteRange, Option<Ty>)>,
 }
 
 impl<'ast> visit::Visitor<'ast> for StructVisitor {
@@ -855,16 +855,13 @@ impl<'ast> visit::Visitor<'ast> for StructVisitor {
         _: Span,
     ) {
         for field in struct_definition.fields() {
-            let source_map::BytePos(point) = field.span.lo();
-
             let ty = Ty::from_ast(&field.ty, &self.scope);
             let name = match field.ident {
                 Some(ref ident) => ident.to_string(),
                 // name unnamed field by its ordinal, since self.0 works
                 None => format!("{}", self.fields.len()),
             };
-
-            self.fields.push((name, point.into(), ty));
+            self.fields.push((name, field.span.into(), ty));
         }
     }
 }
@@ -1024,7 +1021,7 @@ pub fn parse_pat_bind_stmt(s: String) -> Vec<ByteRange> {
     v.ident_points
 }
 
-pub fn parse_struct_fields(s: String, scope: Scope) -> Vec<(String, BytePos, Option<Ty>)> {
+pub fn parse_struct_fields(s: String, scope: Scope) -> Vec<(String, ByteRange, Option<Ty>)> {
     let mut v = StructVisitor {
         scope,
         fields: Vec::new(),

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -45,23 +45,19 @@ pub(crate) fn search_struct_fields(
         _ => src[struct_range.clone()].to_string(),
     };
     let fields = ast::parse_struct_fields(structsrc, core::Scope::from_match(structmatch));
-    for (field, field_point, ty) in fields {
+    for (field, field_range, _) in fields {
         if symbol_matches(search_type, searchstr, &field) {
-            let contextstr = if let Some(t) = ty {
-                t.to_string()
-            } else {
-                field.clone()
-            };
             let raw_src = session.load_raw_file(&structmatch.filepath);
+            let contextstr = src[field_range.shift(struct_start).to_range()].to_owned();
             out.push(Match {
                 matchstr: field,
                 filepath: structmatch.filepath.clone(),
-                point: field_point + struct_start,
+                point: field_range.start + struct_start,
                 coords: None,
                 local: structmatch.local,
                 mtype: MatchType::StructField,
-                contextstr: contextstr,
-                docs: find_doc(&raw_src[struct_range.clone()], field_point),
+                contextstr,
+                docs: find_doc(&raw_src[struct_range.clone()], field_range.start),
             });
         }
     }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -3,7 +3,9 @@
 use ast;
 use ast_types::{Pat, Ty};
 use core;
-use core::{BytePos, Match, MatchType, Namespace, Scope, SearchType, Session, SessionExt, Src};
+use core::{
+    BytePos, ByteRange, Match, MatchType, Namespace, Scope, SearchType, Session, SessionExt, Src,
+};
 use matchers;
 use nameres;
 use primitive::PrimKind;
@@ -376,7 +378,7 @@ pub fn get_struct_field_type(
 pub(crate) fn get_tuplestruct_fields(
     structmatch: &Match,
     session: &Session,
-) -> Vec<(String, BytePos, Option<Ty>)> {
+) -> Vec<(String, ByteRange, Option<Ty>)> {
     let src = session.load_source_file(&structmatch.filepath);
     let structsrc = if let core::MatchType::EnumVariant(_) = structmatch.mtype {
         // decorate the enum variant src to make it look like a tuple struct

--- a/tests/struct_field.rs
+++ b/tests/struct_field.rs
@@ -107,3 +107,32 @@ fn finds_struct_field_in_constructor() {
     }"#;
     assert_eq!(get_definition(src, None).matchstr, "id");
 }
+
+#[test]
+fn struct_field_scalar_primitive_types() {
+    let src = "
+    struct Foo<'a> {
+        reference: &'a u8,
+        array: [u8; 5],
+        slice: &'a [u8],
+    }
+
+    fn foo(x: Foo) {
+        x.~
+    }
+    ";
+
+    let completions = get_all_completions(src, None);
+    assert_eq!(completions.len(), 3);
+
+    for completion in completions {
+        let expected = match completion.matchstr.as_ref() {
+            "reference" => "reference: &'a u8",
+            "array" => "array: [u8; 5]",
+            "slice" => "slice: &'a [u8]",
+            _ => panic!("unexpected match from Foo struct ({})", completion.matchstr),
+        };
+
+        assert_eq!(completion.contextstr, expected);
+    }
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -957,36 +957,6 @@ fn follows_use_to_inline_mod() {
 }
 
 #[test]
-fn struct_field_scalar_primitive_types() {
-    let src = "
-    struct Foo<'a> {
-        reference: &'a u8,
-        array: [u8; 5],
-        slice: &'a [u8],
-    }
-
-    fn foo(x: Foo) {
-        x.~
-    }
-    ";
-
-    let completions = get_all_completions(src, None);
-    assert_eq!(completions.len(), 3);
-
-    for completion in completions {
-        println!("match: {:?}", completion);
-        let expected = match completion.matchstr.as_ref() {
-            "reference" => "&u8",
-            "array" => "[u8; 5]",
-            "slice" => "&[u8]",
-            _ => panic!("unexpected match from Foo struct ({})", completion.matchstr),
-        };
-
-        assert_eq!(completion.contextstr, expected);
-    }
-}
-
-#[test]
 fn finds_enum() {
     let src = "
     enum MyEnum {

--- a/tests/trait_bounds.rs
+++ b/tests/trait_bounds.rs
@@ -363,3 +363,18 @@ fn completes_assoc_constant_for_type_param_impl_bound() {
     ";
     assert_eq!(get_only_completion(src, None).matchstr, "OFFSET");
 }
+
+#[test]
+fn print_trait_object() {
+    let src = "
+    trait Object {}
+    struct Obj(Box<dyn Object>);
+    fn main() {
+        let obj: Obj = function();
+        obj.~
+    }
+    ";
+    let got = get_only_completion(src, None);
+    assert_eq!(got.matchstr, "0");
+    assert_eq!(got.contextstr, "Box<dyn Object>");
+}


### PR DESCRIPTION
For this struct,
```rust
struct St {
    mem: String,
}
```
before:
```rust
String
```
after:
```rust 
mem: String
```
