### PR TITLE
Re-export Edition

### DIFF
--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -42,7 +42,7 @@ pub use core::{
     BytePos, ByteRange, Coordinate, FileCache, FileLoader, Location, Match, MatchType, Session,
 };
 pub use primitive::PrimKind;
-pub use project_model::ProjectModelProvider;
+pub use project_model::{Edition, ProjectModelProvider};
 pub use snippets::snippet_for_match;
 pub use util::expand_ident;
 


### PR DESCRIPTION
Currently `ProjectModelProvider` cannot be implemented because there is no way to name `Edition`.