### PR TITLE
Correctly count CRLF newlines when counting line offsets.

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -487,7 +487,7 @@ impl RawSource {
         let mut before = 0;
         *self.lines.borrow_mut() = self
             .code
-            .lines()
+            .split('\n')
             .map(|line| {
                 let len = line.len() + 1;
                 let res = ByteRange::new(before, before + len);
@@ -583,6 +583,34 @@ fn myfn() {
     assert_eq!(
         src.coords_to_point(&Coordinate::new(3, 5)),
         Some(BytePos(18))
+    );
+}
+
+#[test]
+fn coords_to_point_lf_newline() {
+    let src = "\n\
+               fn myfn() {\n\
+               let a = 3;\n\
+               print(a);\n\
+               }\n";
+    let src = RawSource::new(src.into());
+    assert_eq!(
+        src.coords_to_point(&Coordinate::new(3, 5)),
+        Some(BytePos(18))
+    );
+}
+
+#[test]
+fn coords_to_point_crlf_newline() {
+    let src = "\r\n\
+               fn myfn() {\r\n\
+               let a = 3;\r\n\
+               print(a);\r\n\
+               }\r\n";
+    let src = RawSource::new(src.into());
+    assert_eq!(
+        src.coords_to_point(&Coordinate::new(3, 5)),
+        Some(BytePos(20))
     );
 }
 


### PR DESCRIPTION
This allows completion coordinates to find the correct position in the file when using Windows style newlines (CRLF). I added two simple tests which are slight tweaks of the coords_to_point_works test in core.rs.

Notably for me, this allows RLS autocomplete to function correctly when working on files with Windows style newlines.

See [issue 976 in the rust-lang/rls repo](https://github.com/rust-lang/rls/issues/976). I believe this behavior was merged to the racer github repo on Jun 24, 2018 with commit 42046fc27cf321dc7c0fc70bdf11e8e4a024b32a.


Example image of the autocomplete problem in VSCode on Windows. This is a file with CRLF newlines. Notice that the cursor is on line 7, but the auto-completion is for the code that exists on line 5.
![image](https://user-images.githubusercontent.com/1094022/49664937-f4eafc80-fa18-11e8-93da-d79c07bbf5e2.png)

Now the autocomplete will autocomplete line 5 at the end of line 5, where the user will want it to. 🎉 
![image](https://user-images.githubusercontent.com/1094022/49665562-ddad0e80-fa1a-11e8-9841-56e117a63a2b.png)
