### PR TITLE
Update rustc-ap-syntax + Bump version to 2.1.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "racer"
-version = "2.1.14"
+version = "2.1.15"
 license = "MIT"
 description = "Code completion for Rust"
 authors = ["Phil Dawes <phil@phildawes.net>", "The Racer developers"]
@@ -24,7 +24,7 @@ debug = false # because of #1005
 [dependencies]
 bitflags = "1.0"
 log = "0.4"
-rustc-ap-syntax = "297.0.0"
+rustc-ap-syntax = "306.0.0"
 env_logger = "0.6"
 clap = "2.32"
 lazy_static = "1.2"


### PR DESCRIPTION
Maybe fix compile in latest nightly.