### PR TITLE
Fix parsing of documentation block comments inside block comments

### DIFF
--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -116,6 +116,7 @@ impl<'a> CodeIndicesIter<'a> {
             pos = pos.increment();
             match b {
                 b'/' if prev == b'*' => {
+                    prev = b' ';
                     if nesting_level == 0 {
                         break;
                     } else {
@@ -123,6 +124,7 @@ impl<'a> CodeIndicesIter<'a> {
                     }
                 }
                 b'*' if prev == b'/' => {
+                    prev = b' ';
                     nesting_level += 1;
                 }
                 _ => {

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -376,6 +376,18 @@ mod code_indices_iter_test {
     }
 
     #[test]
+    fn handles_documentation_block_comments_nested_into_block_comments() {
+        let src = &rejustify(
+            "
+    this is some code /* nested /** documentation block */ comment */ some more code
+    ",
+        );
+        let mut it = code_chunks(src);
+        assert_eq!("this is some code ", slice(src, it.next().unwrap()));
+        assert_eq!(" some more code", slice(src, it.next().unwrap()));
+    }
+
+    #[test]
     fn removes_string_with_escaped_dblquote_in_it() {
         let src = &rejustify(
             "


### PR DESCRIPTION
When a source file contained a documentation block comment `/** doc comment */` that was nested into a block comment, i. e. something like
```
/* this is a /** documentation block comment inside a */ block comment */
```
which might occur when someone uncomments a function together with its documentation, racer failed to provide completions in the entire file.

The problem seems to lie in the method `comment_block` of `codecleaner::CodeIndicesIter`: When reaching the `/**` while parsing the comment, `prev` is first set to `b'/'`. After reaching the first `*`, the nesting level is increased, but `prev` is still `b'/'`, so when the second `*` is reached, the nesting level is increased again, as the previous character is still considered to be a slash.

I was not able to figure out why this does not happen on unnested documentation block comments.

I added a test that tests the behaviour in this case and fixed the `comment_block` by setting `prev` to a whitespace character after `/*` or `*/` is found.