### PR TITLE
Fix enum variant completion for pub(crate)

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -305,7 +305,8 @@ pub fn match_extern_crate(msrc: Src, context: &MatchCxt, session: &Session) -> O
             context.search_type,
             &format!("as {}", context.search_str),
             blob,
-        )) {
+        ))
+    {
         debug!("found an extern crate: |{}|", blob);
 
         let extern_crate = ast::parse_extern_crate(blob.to_owned());
@@ -475,27 +476,21 @@ pub fn match_trait(msrc: Src, context: &MatchCxt, session: &Session) -> Option<M
 pub fn match_enum_variants(msrc: &str, context: &MatchCxt) -> Vec<Match> {
     let blob = &msrc[context.range.to_range()];
     let mut out = Vec::new();
-    if (blob.starts_with("pub enum") || (context.is_local && blob.starts_with("enum")))
-        && txt_matches(context.search_type, context.search_str, blob)
-    {
-        // parse the enum
-        let parsed_enum = ast::parse_enum(blob.to_owned());
-
-        for (name, offset) in parsed_enum.values {
-            if name.starts_with(context.search_str) {
-                let start = context.range.start + offset;
-                let m = Match {
-                    matchstr: name,
-                    filepath: context.filepath.to_path_buf(),
-                    point: start,
-                    coords: None,
-                    local: context.is_local,
-                    mtype: EnumVariant(None),
-                    contextstr: first_line(&blob[offset.0..]),
-                    docs: find_doc(msrc, start),
-                };
-                out.push(m);
-            }
+    let parsed_enum = ast::parse_enum(blob.to_owned());
+    for (name, offset) in parsed_enum.values {
+        if name.starts_with(context.search_str) {
+            let start = context.range.start + offset;
+            let m = Match {
+                matchstr: name,
+                filepath: context.filepath.to_path_buf(),
+                point: start,
+                coords: None,
+                local: context.is_local,
+                mtype: EnumVariant(None),
+                contextstr: first_line(&blob[offset.0..]),
+                docs: find_doc(msrc, start),
+            };
+            out.push(m);
         }
     }
     out

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1613,6 +1613,7 @@ fn get_enum_variants(
     session: &Session,
 ) -> Vec<Match> {
     let mut out = Vec::new();
+    println!("context: {:?}", context);
     match context.mtype {
         // TODO(kngwyu): use generics
         MatchType::Enum(ref _generics) => {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3832,3 +3832,16 @@ fn main() {
     let got = get_only_completion(src, None);
     assert_eq!(got.matchstr, "concat");
 }
+
+#[test]
+fn completes_crate_local_enum_variant() {
+    let src = "
+    pub(crate) enum Enum {
+       Variant,
+    }
+    fn main() {
+        let bar = Enum::V~;
+    }
+    ";
+    assert_eq!(get_only_completion(src, None).matchstr, "Variant");
+}


### PR DESCRIPTION
Now 
```rust
pub(crate) enum Enum {
    Variant,
}
use enum::V~
```
doesn't work.