### PR TITLE
Prefer `debug!` over `println!` in library code

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1613,7 +1613,7 @@ fn get_enum_variants(
     session: &Session,
 ) -> Vec<Match> {
     let mut out = Vec::new();
-    println!("context: {:?}", context);
+    debug!("context: {:?}", context);
     match context.mtype {
         // TODO(kngwyu): use generics
         MatchType::Enum(ref _generics) => {


### PR DESCRIPTION
This should fix completion in RLS since we can't print anything to stdout ourselves (due to LSP), leading to a malformed state.

I'm sorry @kngwyu, could I ask you to release a new version one more time? :bowing_man: I'd like to ship the version with rustc-ap-* v407 but don't want to ship RLS hanging on enum autocompletions :cry: 