### PR TITLE
Use iter() to iterate arrays as a slice

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -763,7 +763,7 @@ impl<'c, 's, 'ast> visit::Visitor<'ast> for ExprTypeVisitor<'c, 's> {
                     if name.as_str() == "vec" {
                         let path = RacerPath::from_iter(
                             true,
-                            ["std", "vec", "Vec"].into_iter().map(|s| s.to_string()),
+                            ["std", "vec", "Vec"].iter().map(|s| s.to_string()),
                         );
                         self.result = find_type_match(
                             &path,

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -858,5 +858,5 @@ pub(crate) fn gen_tuple_fields(u: usize) -> impl Iterator<Item = &'static str> {
     const NUM: [&'static str; 16] = [
         "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
     ];
-    NUM.into_iter().take(::std::cmp::min(u, 16)).map(|x| *x)
+    NUM.iter().take(::std::cmp::min(u, 16)).map(|x| *x)
 }


### PR DESCRIPTION
Fixes these clippy errors:

```text
error: this .into_iter() call is equivalent to .iter() and will not move the array
   --> src/racer/util.rs:861:9
    |
861 |     NUM.into_iter().take(::std::cmp::min(u, 16)).map(|x| *x)
    |         ^^^^^^^^^ help: call directly: `iter`
    |
    = note: requested on the command line with `-D clippy::into-iter-on-array`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_array

error: this .into_iter() call is equivalent to .iter() and will not move the array
   --> src/racer/ast.rs:766:51
    |
766 |                             ["std", "vec", "Vec"].into_iter().map(|s| s.to_string()),
    |                                                   ^^^^^^^^^ help: call directly: `iter`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_array
```