### PR TITLE
Cache current directory in MetadataCache

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -16,7 +16,7 @@ use std::time::SystemTime;
 
 fn point(cfg: &Config) {
     let cache = FileCache::default();
-    let session = Session::new(&cache);
+    let session = Session::new(&cache, None);
     cfg.interface.emit(Message::Coords(cfg.coords()));
     if let Some(point) = racer::to_point(cfg.coords(), cfg.expect_file(), &session) {
         cfg.interface.emit(Message::Point(point));
@@ -26,7 +26,7 @@ fn point(cfg: &Config) {
 
 fn coord(cfg: &Config) {
     let cache = FileCache::default();
-    let session = Session::new(&cache);
+    let session = Session::new(&cache, None);
     cfg.interface.emit(Message::Point(cfg.point));
     if let Some(coords) = racer::to_coords(cfg.point, cfg.expect_file(), &session) {
         cfg.interface.emit(Message::Coords(coords));
@@ -146,9 +146,9 @@ fn run_the_complete_fn(cfg: &Config, print_type: CompletePrinter) {
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
 
     let cache = FileCache::default();
-    let session = Session::new(&cache);
+    let session = Session::new(&cache, Some(fn_path));
 
-    load_query_file(&fn_path, &substitute_file, &session);
+    load_query_file(fn_path, &substitute_file, &session);
 
     if let Some(expanded) = racer::expand_ident(&fn_path, cfg.coords(), &session) {
         cfg.interface.emit(Message::Prefix(
@@ -170,7 +170,7 @@ fn run_the_complete_fn(cfg: &Config, print_type: CompletePrinter) {
 fn external_complete(cfg: &Config, print_type: CompletePrinter) {
     let cwd = Path::new(".");
     let cache = FileCache::default();
-    let session = Session::new(&cache);
+    let session = Session::new(&cache, Some(cwd));
 
     for m in racer::complete_fully_qualified_name(cfg.fqn.as_ref().unwrap(), &cwd, &session) {
         match print_type {
@@ -184,10 +184,10 @@ fn prefix(cfg: &Config) {
     let fn_path = cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
     let cache = FileCache::default();
-    let session = Session::new(&cache);
+    let session = Session::new(&cache, Some(fn_path));
 
     // Cache query file in session
-    load_query_file(&fn_path, &substitute_file, &session);
+    load_query_file(fn_path, &substitute_file, &session);
 
     // print the start, end, and the identifier prefix being matched
     let expanded = racer::expand_ident(fn_path, cfg.coords(), &session).unwrap();
@@ -202,10 +202,10 @@ fn find_definition(cfg: &Config) {
     let fn_path = cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
     let cache = FileCache::default();
-    let session = Session::new(&cache);
+    let session = Session::new(&cache, Some(fn_path));
 
     // Cache query file in session
-    load_query_file(&fn_path, &substitute_file, &session);
+    load_query_file(fn_path, &substitute_file, &session);
 
     if let Some(m) = racer::find_definition(fn_path, cfg.coords(), &session) {
         match_fn(m, cfg.interface);

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -757,8 +757,9 @@ fn search_fn_args_and_generics(
 #[test]
 fn test_do_file_search_std() {
     let cache = core::FileCache::default();
-    let session = Session::new(&cache);
-    let matches = do_file_search("std", &Path::new("."), &session);
+    let path = Path::new(".");
+    let session = Session::new(&cache, Some(path));
+    let matches = do_file_search("std", path, &session);
     assert!(matches
         .into_iter()
         .any(|m| m.filepath.ends_with("src/libstd/lib.rs")));
@@ -767,8 +768,9 @@ fn test_do_file_search_std() {
 #[test]
 fn test_do_file_search_local() {
     let cache = core::FileCache::default();
-    let session = Session::new(&cache);
-    let matches = do_file_search("submodule", &Path::new("fixtures/arst/src"), &session);
+    let path = Path::new("fixtures/arst/src");
+    let session = Session::new(&cache, Some(path));
+    let matches = do_file_search("submodule", path, &session);
     assert!(matches
         .into_iter()
         .any(|m| m.filepath.ends_with("fixtures/arst/src/submodule/mod.rs")));

--- a/src/racer/project_model.rs
+++ b/src/racer/project_model.rs
@@ -12,7 +12,7 @@ pub trait ProjectModelProvider {
     fn search_dependencies(
         &self,
         manifest: &Path,
-        search_fn: Box<Fn(&str) -> bool>,
+        search_fn: Box<dyn Fn(&str) -> bool>,
     ) -> Vec<(String, PathBuf)>;
     fn resolve_dependency(&self, manifest: &Path, dep_name: &str) -> Option<PathBuf>;
 }

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -19,7 +19,7 @@ use syntax::ast::ImplItemKind;
 ///
 /// let path = Path::new(".");
 /// let cache = racer::FileCache::default();
-/// let session = racer::Session::new(&cache);
+/// let session = racer::Session::new(&cache, Some(path));
 ///
 /// let m = racer::complete_fully_qualified_name(
 ///     "std::fs::canonicalize",

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -280,7 +280,7 @@ fn txt_matches_matches_methods() {
 /// let path = "lib.rs";
 ///
 /// let cache = racer::FileCache::default();
-/// let session = racer::Session::new(&cache);
+/// let session = racer::Session::new(&cache, None);
 ///
 /// session.cache_file_contents(path, src);
 ///

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -410,19 +410,7 @@ pub enum RustSrcPathError {
     NotRustSourceTree(path::PathBuf),
 }
 
-impl error::Error for RustSrcPathError {
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            RustSrcPathError::Missing => "RUSTC_SRC_PATH not set or not found in sysroot",
-            RustSrcPathError::DoesNotExist(_) => "RUSTC_SRC_PATH does not exist on file system",
-            RustSrcPathError::NotRustSourceTree(_) => "RUSTC_SRC_PATH isn't a rustc source tree",
-        }
-    }
-}
+impl error::Error for RustSrcPathError {}
 
 impl fmt::Display for RustSrcPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -106,8 +106,8 @@ fn completes_fn_with_substitute_file() {
     let (_pos, src) = get_pos_and_source(src);
     let cache = racer::FileCache::default();
     let real_file = Path::new("not_real.rs");
-    let session = racer::Session::new(&cache);
-    session.cache_file_contents(&real_file, src);
+    let session = racer::Session::new(&cache, None);
+    session.cache_file_contents(real_file, src);
     let cursor = Coordinate::new(6, 18);
     let got = complete_from_file(real_file, cursor, &session)
         .nth(0)
@@ -145,9 +145,9 @@ fn completes_pub_fn_locally_precached() {
     let f = TmpFile::new(&src);
     let path = f.path();
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
-    session.cache_file_contents(&path, src.clone());
-    let got = complete_from_file(&path, pos, &session).nth(0).unwrap();
+    let session = racer::Session::new(&cache, Some(path));
+    session.cache_file_contents(path, src.clone());
+    let got = complete_from_file(path, pos, &session).nth(0).unwrap();
     assert_eq!("apple", got.matchstr);
 }
 
@@ -221,7 +221,7 @@ fn completes_for_vec_field_and_method() {
     let dir = TmpDir::new();
     let path = dir.write_file("src.rs", src);
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
+    let session = racer::Session::new(&cache, None);
     let cursor1 = Coordinate::new(18, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
     assert_eq!("stfield", got1.matchstr);
@@ -256,13 +256,13 @@ fn completes_trait_methods() {
     let f = TmpFile::new(src);
     let path = f.path();
     let cache1 = racer::FileCache::default();
-    let session1 = racer::Session::new(&cache1);
+    let session1 = racer::Session::new(&cache1, None);
     let cursor1 = Coordinate::new(18, 18);
     let got1 = complete_from_file(&path, cursor1, &session1)
         .nth(0)
         .unwrap();
     let cache2 = racer::FileCache::default();
-    let session2 = racer::Session::new(&cache2);
+    let session2 = racer::Session::new(&cache2, None);
     let cursor2 = Coordinate::new(19, 11);
     let got2 = complete_from_file(&path, cursor2, &session2)
         .nth(0)
@@ -302,13 +302,13 @@ fn completes_trait_bounded_methods() {
     let f = TmpFile::new(src);
     let path = f.path();
     let cache1 = racer::FileCache::default();
-    let session1 = racer::Session::new(&cache1);
+    let session1 = racer::Session::new(&cache1, None);
     let cursor1 = Coordinate::new(20, 16);
     let got1 = complete_from_file(&path, cursor1, &session1)
         .nth(0)
         .unwrap();
     let cache2 = racer::FileCache::default();
-    let session2 = racer::Session::new(&cache2);
+    let session2 = racer::Session::new(&cache2, None);
     let cursor2 = Coordinate::new(21, 12);
     let got2 = complete_from_file(&path, cursor2, &session2)
         .nth(0)
@@ -353,7 +353,7 @@ fn completes_trait_bounded_methods_generic_return() {
     let f = TmpFile::new(src);
     let path = f.path();
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
+    let session = racer::Session::new(&cache, None);
     let cursor1 = Coordinate::new(24, 24);
     let cursor2 = Coordinate::new(25, 25);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
@@ -436,7 +436,7 @@ fn completes_for_vec_iter_field_and_method() {
     let dir = TmpDir::new();
     let path = dir.write_file("src.rs", src);
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
+    let session = racer::Session::new(&cache, None);
     let cursor1 = Coordinate::new(22, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
     assert_eq!("stfield", got1.matchstr);
@@ -472,7 +472,7 @@ fn completes_trait_methods_when_at_scope_end() {
     let f = TmpFile::new(src);
     let path = f.path();
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
+    let session = racer::Session::new(&cache, None);
     let cursor1 = Coordinate::new(18, 18);
     let got1 = complete_from_file(&path, cursor1, &session).nth(0).unwrap();
     let cursor2 = Coordinate::new(19, 11);

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -192,7 +192,7 @@ pub fn get_all_completions_with_name(src: &str, dir: Option<TmpDir>, fname: &str
     let (completion_point, clean_src) = get_pos_and_source(src);
     let path = dir.write_file(fname, &clean_src);
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
+    let session = racer::Session::new(&cache, Some(path.as_ref()));
     complete_from_file(&path, completion_point, &session).collect()
 }
 
@@ -233,6 +233,6 @@ pub fn find_definition_with_name(src: &str, dir: Option<TmpDir>, fname: &str) ->
     let (completion_point, clean_src) = get_pos_and_source(src);
     let path = dir.write_file(fname, &clean_src);
     let cache = racer::FileCache::default();
-    let session = racer::Session::new(&cache);
+    let session = racer::Session::new(&cache, Some(path.as_ref()));
     racer_find_definition(&path, completion_point, &session)
 }


### PR DESCRIPTION
This hack prevents calling `cargo metadata` in stdlib/libsyntax directories.