### PR TITLE
Fixed finding arg list in methods.

### DIFF
--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -80,7 +80,7 @@ pub fn first_param_is_self(blob: &str) -> bool {
                 Some(..) => 0,
             };
             if let Some(start) = blob[skip_generic..].find('(') {
-                let start = BytePos::from(start).increment();
+                let start = BytePos::from(skip_generic + start).increment();
                 let end = scopes::find_closing_paren(blob, start);
                 let is_self = txt_matches(SearchType::ExactMatch, "self", &blob[start.0..end.0]);
                 trace!(

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1978,6 +1978,27 @@ fn finds_self_param_when_fn_has_generic_closure_arg() {
 }
 
 #[test]
+fn completes_static_method_containing_self() {
+    let src = "
+    struct X;
+    
+    impl X {
+        fn foo<T>(_: T) {
+            struct Y;
+            impl Y {
+                fn bar(&self) {}
+            }
+        }
+    }
+
+    X::~foo(0);
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("foo", got.matchstr);
+}
+
+#[test]
 fn completes_methods_on_deref_generic_type() {
     let modsrc = "
     pub struct B<T> {


### PR DESCRIPTION
This will fix racer believing a static method is not, in fact, a static method, in the case that `self` appears on the inside of the function.

Fixes #1064.