### PR TITLE
Update rustc-ap-syntax to 583.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
  "racer-cargo-metadata 0.1.1",
  "racer-testutils 0.1.0",
  "rls-span 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -573,21 +573,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -598,8 +598,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-graphviz 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-graphviz 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -609,15 +609,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,19 +645,19 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,33 +666,33 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-syntax_pos"
-version = "581.0.0"
+version = "583.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1021,16 +1021,16 @@ dependencies = [
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rls-span 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2e9bed56f6272bd85d9d06d1aaeef80c5fddc78a82199eb36dceb5f94e7d934"
-"checksum rustc-ap-arena 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4efec6ece174df54e4605c3c229b5a8885355f9f8988cabbc24aa99dbc27f27"
-"checksum rustc-ap-graphviz 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b01d685fc49fb05676a8829c7a9fa1759c441f1430384c32c8b42462409535f3"
-"checksum rustc-ap-rustc_data_structures 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e43082631e0b3782c216d02d7d86a221b58834a1b3ba2b686aa84309bd65ed9"
-"checksum rustc-ap-rustc_errors 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ad386fc563e7e5ab47d78eaf2ee37d430e1e6c0ca67a23df70fdee9c4bdf673"
-"checksum rustc-ap-rustc_lexer 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3820240b53041ee8932c866aaf9c877e3a55af31a2f5c333077b853e9bed2ac"
-"checksum rustc-ap-rustc_macros 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89b0931fe770efb7bc659e1900ef80d7bc8efeb4a36af94c5a89bea9e0230989"
-"checksum rustc-ap-rustc_target 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26a3d9de9e308ba21add5f92bc2dfd014f3ea06932df7ba10ac23c83c0c9bc03"
-"checksum rustc-ap-serialize 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9f98141be65d2cc0bc8eb11e89bda9d4cec9ddf69dd46120c8f3840f9b5adc"
-"checksum rustc-ap-syntax 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5643c677373d8fa1f19c93ce7b42f5628818964d4d3d7dc6ac191b2b6170e91b"
-"checksum rustc-ap-syntax_pos 581.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1508b6dc46181580787b30876bc8cc1c76ca5851aec05d08e0065cd16c635736"
+"checksum rustc-ap-arena 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f59b76d334bd533f3fdc5c651c27678c5e80fac67c6f7da22ba21a58878c55f5"
+"checksum rustc-ap-graphviz 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e632ef08ca17458acfd46d2ead3d541a1c249586cd5329f5fe333dacfab6142"
+"checksum rustc-ap-rustc_data_structures 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e89e2c7be68185418f3cd56af3df8b29007a59a1cebefa63612d055f9bcb1a36"
+"checksum rustc-ap-rustc_errors 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e47cb380abeb72b01e42b2342d592f7eeea7d536c2f1f0d0e550dc509e46333"
+"checksum rustc-ap-rustc_lexer 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "494cfaf67f49217d67d0774eeecbba61ac89acf478db97ef11f113ed8a959305"
+"checksum rustc-ap-rustc_macros 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e5d36becc59b4497f9cbd3ae0610081de0207a1d0e95c066369167b14f486f"
+"checksum rustc-ap-rustc_target 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7bfc5f96dfc3b9f8d5b57884f7f37467ecff6776cd4b8b491a7daece6fdd7c2"
+"checksum rustc-ap-serialize 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bb9ee231cf79eded39c56647499f83d6136ff5c8c0baaa9e21b6febee00f4f6"
+"checksum rustc-ap-syntax 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3827fc208814efbde82d613e31d11b4250ce9e8cf8afe4a4d47bbbd099632c9"
+"checksum rustc-ap-syntax_pos 583.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "930ed81c34f325e512cc315c04d676fa84a373879d5c43bb54054a0522b05213"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2e07e19601f21c59aad953c2632172ba70cb27e685771514ea66e4062b3363"
 "checksum rustc-rayon-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79d38ca7cbc22fa59f09d8534ea4b27f67b0facf0cbe274433aceea227a02543"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ debug = false # because of #1005
 [dependencies]
 bitflags = "1.0"
 log = "0.4"
-rustc-ap-syntax = "581.0.0"
+rustc-ap-syntax = "583.0.0"
 env_logger = "0.6"
 clap = "2.32"
 lazy_static = "1.2"


### PR DESCRIPTION
Required some changes in ast module. Let expressions and match arms expressions only hold a single pattern.