### PR TITLE
Fix the default value of RUST_SRC_PATH

### DIFF
--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -451,13 +451,13 @@ fn check_rust_sysroot() -> Option<path::PathBuf> {
     if let Ok(output) = cmd.output() {
         if let Ok(s) = String::from_utf8(output.stdout) {
             let sysroot = path::Path::new(s.trim());
-            let srcpath = sysroot.join("lib/rustlib/src/rust/src");
-            if srcpath.exists() {
-                return Some(srcpath);
-            }
             // See if the toolchain is sufficiently new, after the libstd
             // has been internally reorganized
             let srcpath = sysroot.join("lib/rustlib/src/rust/library");
+            if srcpath.exists() {
+                return Some(srcpath);
+            }
+            let srcpath = sysroot.join("lib/rustlib/src/rust/src");
             if srcpath.exists() {
                 return Some(srcpath);
             }
@@ -545,7 +545,6 @@ fn validate_rust_src_path(path: path::PathBuf) -> Result<path::PathBuf, RustSrcP
     if path.join("libstd").exists() || path.join("std").join("src").exists() {
         Ok(path)
     } else {
-
         Err(RustSrcPathError::NotRustSourceTree(path.join("libstd")))
     }
 }


### PR DESCRIPTION
Both `rust/library` and `rust/src` exist in the current version, the `std` directory is not matched correctly.

```shell
$ rustc --version
rustc 1.48.0-nightly (0da580074 2020-09-22)

$ racer --version
racer 2.1.39

$ racer complete std::io::B                         
Unable to find libstd under RUST_SRC_PATH. N.B. RUST_SRC_PATH variable needs to point to the *src* directory inside a rust checkout e.g. "/home/foouser/src/rust/src". Current value ""/Users/xuyizhe/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd""
```