### PR TITLE
Just update docs to reflect new location of rust source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As mentioned in the command output, don't forget to add the installation directo
 
 1. Fetch the Rust sourcecode
 
-    1. automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `$(rustc --print sysroot)/lib/rustlib/src/rust/library` (or `$(rustc --print sysroot)/lib/rustlib/src/rust/library` in older toolchains). Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
+    1. automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `$(rustc --print sysroot)/lib/rustlib/src/rust/library` (or `$(rustc --print sysroot)/lib/rustlib/src/rust/src` in older toolchains). Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
 
     2. manually from git: https://github.com/rust-lang/rust
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As mentioned in the command output, don't forget to add the installation directo
 
 1. Fetch the Rust sourcecode
 
-    1. automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `$(rustc --print sysroot)/lib/rustlib/src/rust/src`. Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
+    1. automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `$(rustc --print sysroot)/lib/rustlib/src/rust/library` (or `$(rustc --print sysroot)/lib/rustlib/src/rust/library` in older toolchains). Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
 
     2. manually from git: https://github.com/rust-lang/rust
 

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -419,7 +419,7 @@ impl fmt::Display for RustSrcPathError {
                 f,
                 "RUST_SRC_PATH environment variable must be set to \
                  point to the src directory of a rust checkout. \
-                 E.g. \"/home/foouser/src/rust/src\""
+                 E.g. \"/home/foouser/src/rust/library\"  (or  \"/home/foouser/src/rust/src\" in older toolchains)"
             ),
             RustSrcPathError::DoesNotExist(ref path) => write!(
                 f,
@@ -427,7 +427,7 @@ impl fmt::Display for RustSrcPathError {
                  RUST_SRC_PATH variable \"{:?}\". Try using an \
                  absolute fully qualified path and make sure it \
                  points to the src directory of a rust checkout - \
-                 e.g. \"/home/foouser/src/rust/src\".",
+                 e.g. \"/home/foouser/src/rust/library\" (or  \"/home/foouser/src/rust/src\" in older toolchains).",
                 path
             ),
             RustSrcPathError::NotRustSourceTree(ref path) => write!(
@@ -435,7 +435,7 @@ impl fmt::Display for RustSrcPathError {
                 "Unable to find libstd under RUST_SRC_PATH. N.B. \
                  RUST_SRC_PATH variable needs to point to the *src* \
                  directory inside a rust checkout e.g. \
-                 \"/home/foouser/src/rust/src\". \
+                 \"/home/foouser/src/rust/library\" (or  \"/home/foouser/src/rust/src\" in older toolchains). \
                  Current value \"{:?}\"",
                 path
             ),


### PR DESCRIPTION
Since [rust-lang/rust/pull/73265](https://github.com/rust-lang/rust/pull/73265), location of rust source files has changed and after [this merge](https://github.com/racer-rust/racer/pull/1130), the documentation in the README and other places (e.g. src/racer/util.rs) needs to reflect that the rust source is now in `...lib/rustlib/src/rust/library` instead of `lib/rustlib/src/rust/src`. 

I changed the documentation to reflect both the new location and the old one for those with old rust distributions.