### PR TITLE
Build and test all workspace packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
       - run: rustup set default-host ${{ matrix.toolchain }}
       - run: rustup component add rust-src
       - run: rustc -vV
-      - run: cargo build --verbose
-      - run: cargo test
+      - run: cargo build --verbose --all
+      - run: cargo test --all

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # *Racer* - code completion for [Rust](http://www.rust-lang.org/)
 
+[![Build Status](https://github.com/racer-rust/racer/workflows/CI/badge.svg?branch=master)](https://github.com/racer-rust/racer/actions?query=workflow%3ACI+branch%3Amaster)
 [![Build Status](https://travis-ci.org/racer-rust/racer.svg?branch=master)](https://travis-ci.org/racer-rust/racer)
-[![Build status](https://ci.appveyor.com/api/projects/status/hq51xvr5wpfcfqgt/branch/master?svg=true)](https://ci.appveyor.com/project/TedDriggs/racer-xr5g5/branch/master)
 
 
 ![racer completion screenshot](images/racer_completion.png)


### PR DESCRIPTION
Follow-up to #1146

I lost the `--all` option when migrating, sorry about that. Will merge once CI is green.