### PR TITLE
Add support for Rust 2021.

### DIFF
--- a/metadata/src/mapping.rs
+++ b/metadata/src/mapping.rs
@@ -11,10 +11,11 @@ pub struct PackageMap {
     packages: Vec<PackageInner>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Edition {
     Ed2015,
     Ed2018,
+    Ed2021,
 }
 
 impl Edition {
@@ -22,6 +23,7 @@ impl Edition {
         match s {
             "2015" => Edition::Ed2015,
             "2018" => Edition::Ed2018,
+            "2021" => Edition::Ed2021,
             _ => unreachable!("got unexpected edition {}", s),
         }
     }

--- a/src/racer/fileres.rs
+++ b/src/racer/fileres.rs
@@ -41,7 +41,7 @@ pub fn search_crate_names(
             .project_model
             .edition(&manifest_path)
             .unwrap_or(Edition::Ed2015);
-        if edition == Edition::Ed2015 {
+        if edition < Edition::Ed2018 {
             return Vec::new();
         }
     }

--- a/src/racer/metadata.rs
+++ b/src/racer/metadata.rs
@@ -66,6 +66,7 @@ impl ProjectModelProvider for MetadataCache {
         Some(match edition {
             Ed::Ed2015 => Edition::Ed2015,
             Ed::Ed2018 => Edition::Ed2018,
+            Ed::Ed2021 => Edition::Ed2021,
         })
     }
     fn discover_project_manifest(&self, path: &Path) -> Option<PathBuf> {

--- a/src/racer/project_model.rs
+++ b/src/racer/project_model.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Edition {
     Ed2015,
     Ed2018,
+    Ed2021,
 }
 
 pub trait ProjectModelProvider {


### PR DESCRIPTION
This adds support for Rust 2021.

For now, Rust 2021 is identical to Rust 2018.