### PR TITLE
bump rustc-ap crates to v722

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,31 +39,31 @@ path = "metadata"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "718.0.0"
+version = "722.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "718.0.0"
+version = "722.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "718.0.0"
+version = "722.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "718.0.0"
+version = "722.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "718.0.0"
+version = "722.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "718.0.0"
+version = "722.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "718.0.0"
+version = "722.0.0"
 
 [dev-dependencies.racer-testutils]
 version = "0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-05-19"
+channel = "nightly-2021-06-06"
 components = ["rust-src"]


### PR DESCRIPTION
cargo install racer failed!
bump rustc-ap crates to v722

version
```
mac
rustup 1.24.2 (755e2b07e 2021-05-12)
rustc 1.54.0-nightly (6c2dd251b 2021-06-05)
cargo 1.54.0-nightly (0cecbd673 2021-06-01)
```
log
```
   Compiling rustc-ap-rustc_arena v718.0.0
   Compiling rustc-ap-rustc_span v718.0.0
error[E0199]: implementing the trait `Step` is not unsafe
  --> /Users/luoxiaobing/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-rustc_span-718.0.0/src/def_id.rs:12:1
   |
12 | / rustc_index::newtype_index! {
13 | |     pub struct CrateId {
14 | |         ENCODABLE = custom
15 | |     }
16 | | }
   | |_^
   |
   = note: this error originates in the macro `$crate::newtype_index` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0199]: implementing the trait `Step` is not unsafe
   --> /Users/luoxiaobing/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-rustc_span-718.0.0/src/def_id.rs:208:1
    |
208 | / rustc_index::newtype_index! {
209 | |     /// A DefIndex is an index into the hir-map for a crate, identifying a
210 | |     /// particular definition. It should really be considered an interned
211 | |     /// shorthand for a particular DefPath.
...   |
219 | |     }
220 | | }
    | |_^
    |
    = note: this error originates in the macro `$crate::newtype_index` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0199]: implementing the trait `Step` is not unsafe
    --> /Users/luoxiaobing/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-rustc_span-718.0.0/src/symbol.rs:1510:1
     |
1510 | / rustc_index::newtype_index! {
1511 | |     pub struct SymbolIndex { .. }
1512 | | }
     | |_^
     |
     = note: this error originates in the macro `$crate::newtype_index` (in Nightly builds, run with -Z macro-backtrace for more info)

   Compiling racer-interner v0.1.0 (/Users/luoxiaobing/.cargo/git/checkouts/racer-9015ab70fb56071b/6bbd6a2/interner)
error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0199`.
error: could not compile `rustc-ap-rustc_span`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `racer v2.1.47 (https://github.com/racer-rust/racer.git#6bbd6a2a)`, intermediate artifacts can be found at `/var/folders/5v/qhx00kf14hq7zd90pk856n700000gn/T/cargo-installGT3wSP`

Caused by:
  build failed
```