### PR TITLE
Fx breakage caused by the introduction of diagnostic translations

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-01-14"
+channel = "2022-04-06"
 components = ["rust-src", "rustc-dev"]

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -30,6 +30,12 @@ impl Emitter for DummyEmitter {
     fn should_show_explain(&self) -> bool {
         false
     }
+    fn fluent_bundle(&self) -> Option<&Lrc<rustc_errors::FluentBundle>> {
+        None
+    }
+    fn fallback_fluent_bundle(&self) -> &Lrc<rustc_errors::FluentBundle> {
+        unimplemented!("diagnostic translations are unimplemented in racer");
+    }
 }
 
 /// construct parser from string


### PR DESCRIPTION
This fixes the breakage caused by https://github.com/rust-lang/rust/pull/95512, which is going to be in *tomorrow*'s nightly. I expect CI to fail today due to that, but opening the PR in the meantime.